### PR TITLE
Use env vars for credentials and paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ bolsa_app/
 
 ## Configuración Personalizada
 
-Esta aplicación está configurada para trabajar con los siguientes directorios personalizados:
+Esta aplicación utiliza las rutas definidas en las variables de entorno `BOLSA_SCRIPTS_DIR` y `BOLSA_LOGS_DIR`:
 
-- **Scripts de scraping**: `C:\Users\alcai\Desktop\Acciones\Automatizacion\bolsa_santiago_bot.py`
-- **Archivos JSON generados**: `C:\Users\alcai\Desktop\Acciones\Automatizacion\logs_bolsa\acciones-precios-plus_*.json`
+- **Scripts de scraping**: `<BOLSA_SCRIPTS_DIR>/bolsa_santiago_bot.py`
+- **Archivos JSON generados**: `<BOLSA_LOGS_DIR>/acciones-precios-plus_*.json`
 
 La aplicación siempre selecciona el archivo JSON más reciente basándose en la fecha de modificación y muestra el timestamp extraído del nombre del archivo en la interfaz.
 
@@ -86,6 +86,14 @@ La aplicación normaliza automáticamente los nombres de los campos para mantene
 - Navegador web moderno (Chrome, Firefox, Edge, Safari)
 - Conexión a Internet
 - Scripts bolsa_santiago_bot.py y har_analyzer.py en la ubicación especificada
+
+## Variables de Entorno
+
+Antes de ejecutar la aplicación se deben definir las siguientes variables de entorno:
+
+- **BOLSA_USERNAME** y **BOLSA_PASSWORD**: credenciales para iniciar sesión en el sitio de la Bolsa de Santiago.
+- **BOLSA_SCRIPTS_DIR**: ruta al directorio que contiene `bolsa_santiago_bot.py`.
+- **BOLSA_LOGS_DIR**: (opcional) directorio donde el bot almacenará sus logs y archivos JSON. Por defecto se usa `logs_bolsa` dentro de `BOLSA_SCRIPTS_DIR`.
 
 ## Instalación y Ejecución
 
@@ -158,10 +166,7 @@ La aplicación normaliza automáticamente los nombres de los campos para mantene
 
 ## Personalización Adicional
 
-Si necesitas cambiar las rutas de los archivos, puedes modificar las siguientes variables en el archivo `src/scripts/bolsa_service.py`:
+Para cambiar las rutas de los archivos de scraping puedes definir las variables
+de entorno `BOLSA_SCRIPTS_DIR` y `BOLSA_LOGS_DIR` antes de ejecutar la
+aplicación. Así no es necesario modificar el código de `bolsa_service.py`.
 
-```python
-# Configuración de rutas personalizadas para Windows
-SCRIPTS_DIR = r"C:\Users\alcai\Desktop\Acciones\Automatizacion"
-LOGS_DIR = os.path.join(SCRIPTS_DIR, "logs_bolsa")
-```

--- a/bolsa_santiago_bot.py
+++ b/bolsa_santiago_bot.py
@@ -24,8 +24,13 @@ logger_instance_global = logging.getLogger(__name__)
 INITIAL_PAGE_URL = "https://www.bolsadesantiago.com/plus_acciones_precios"
 TARGET_DATA_PAGE_URL = "https://www.bolsadesantiago.com/plus_acciones_precios"
 
-USERNAME = "alcaicey@gmail.com"
-PASSWORD = "Carlosirenee13#"
+USERNAME = os.environ.get("BOLSA_USERNAME")
+PASSWORD = os.environ.get("BOLSA_PASSWORD")
+
+if not USERNAME or not PASSWORD:
+    raise ValueError(
+        "Environment variables BOLSA_USERNAME and BOLSA_PASSWORD must be set"
+    )
 
 USERNAME_SELECTOR = "#username"
 PASSWORD_SELECTOR = "#password"

--- a/src/scripts/bolsa_santiago_bot.py
+++ b/src/scripts/bolsa_santiago_bot.py
@@ -24,8 +24,13 @@ logger_instance_global = logging.getLogger(__name__)
 INITIAL_PAGE_URL = "https://www.bolsadesantiago.com/plus_acciones_precios"
 TARGET_DATA_PAGE_URL = "https://www.bolsadesantiago.com/plus_acciones_precios"
 
-USERNAME = "alcaicey@gmail.com"
-PASSWORD = "Carlosirenee13#"
+USERNAME = os.environ.get("BOLSA_USERNAME")
+PASSWORD = os.environ.get("BOLSA_PASSWORD")
+
+if not USERNAME or not PASSWORD:
+    raise ValueError(
+        "Environment variables BOLSA_USERNAME and BOLSA_PASSWORD must be set"
+    )
 
 USERNAME_SELECTOR = "#username"
 PASSWORD_SELECTOR = "#password"

--- a/src/scripts/bolsa_service.py
+++ b/src/scripts/bolsa_service.py
@@ -9,9 +9,12 @@ import re
 import glob
 import random # Asegurarse de que random esté importado
 
-# Configuración de rutas personalizadas para Windows
-SCRIPTS_DIR = r"C:\Users\alcai\Desktop\Acciones\Automatizacion" # Directorio donde está bolsa_santiago_bot.py
-LOGS_DIR = os.path.join(SCRIPTS_DIR, "logs_bolsa") # Directorio donde bolsa_santiago_bot.py guarda sus logs y JSON
+# Configuración de rutas obtenidas desde variables de entorno
+SCRIPTS_DIR = os.environ.get("BOLSA_SCRIPTS_DIR")
+if not SCRIPTS_DIR:
+    raise ValueError("Environment variable BOLSA_SCRIPTS_DIR must be set")
+
+LOGS_DIR = os.environ.get("BOLSA_LOGS_DIR", os.path.join(SCRIPTS_DIR, "logs_bolsa"))
 
 # Configuración de logging para este script de servicio/orquestador
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- read credentials from `BOLSA_USERNAME` and `BOLSA_PASSWORD`
- read script and log paths from `BOLSA_SCRIPTS_DIR` and `BOLSA_LOGS_DIR`
- document required environment variables

## Testing
- `python -m py_compile bolsa_santiago_bot.py src/scripts/bolsa_santiago_bot.py src/scripts/bolsa_service.py`

------
https://chatgpt.com/codex/tasks/task_e_6841b5946edc8330b759cd2992e0adf4