### PR TITLE
Centralize config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ bolsa_app/
 
 ## Configuración Personalizada
 
-Esta aplicación utiliza las rutas definidas en las variables de entorno `BOLSA_SCRIPTS_DIR` y `BOLSA_LOGS_DIR`:
+Esta aplicación utiliza un archivo de configuración (`src/config.py`) donde se definen las rutas por defecto y otros parámetros estáticos. Las variables de entorno `BOLSA_SCRIPTS_DIR` y `BOLSA_LOGS_DIR` son opcionales y permiten sobrescribir dichas rutas:
 
 - **Scripts de scraping**: `<BOLSA_SCRIPTS_DIR>/bolsa_santiago_bot.py`
 - **Archivos JSON generados**: `<BOLSA_LOGS_DIR>/acciones-precios-plus_*.json`
@@ -92,8 +92,8 @@ La aplicación normaliza automáticamente los nombres de los campos para mantene
 Antes de ejecutar la aplicación se deben definir las siguientes variables de entorno:
 
 - **BOLSA_USERNAME** y **BOLSA_PASSWORD**: credenciales para iniciar sesión en el sitio de la Bolsa de Santiago.
-- **BOLSA_SCRIPTS_DIR**: ruta al directorio que contiene `bolsa_santiago_bot.py`.
-- **BOLSA_LOGS_DIR**: (opcional) directorio donde el bot almacenará sus logs y archivos JSON. Por defecto se usa `logs_bolsa` dentro de `BOLSA_SCRIPTS_DIR`.
+- **BOLSA_SCRIPTS_DIR**: (opcional) ruta al directorio que contiene `bolsa_santiago_bot.py`. Por defecto apunta a la carpeta `src/scripts` del proyecto.
+- **BOLSA_LOGS_DIR**: (opcional) directorio donde el bot almacenará sus logs y archivos JSON. Si no se especifica se utiliza `logs_bolsa` dentro de `BOLSA_SCRIPTS_DIR`.
 
 ## Instalación y Ejecución
 
@@ -166,7 +166,7 @@ Antes de ejecutar la aplicación se deben definir las siguientes variables de en
 
 ## Personalización Adicional
 
-Para cambiar las rutas de los archivos de scraping puedes definir las variables
-de entorno `BOLSA_SCRIPTS_DIR` y `BOLSA_LOGS_DIR` antes de ejecutar la
-aplicación. Así no es necesario modificar el código de `bolsa_service.py`.
+Si necesitas usar rutas diferentes a las predeterminadas puedes definir las
+variables de entorno `BOLSA_SCRIPTS_DIR` y `BOLSA_LOGS_DIR` antes de ejecutar la
+aplicación. De esta forma no es necesario modificar `src/config.py`.
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,40 @@
+import os
+
+BASE_DIR = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
+PROJECT_SRC_DIR = os.path.join(BASE_DIR, 'src')
+
+# Directorio con los scripts de scraping
+SCRIPTS_DIR = os.environ.get('BOLSA_SCRIPTS_DIR', os.path.join(PROJECT_SRC_DIR, 'scripts'))
+
+# Directorio donde se guardan los logs y archivos JSON generados por el bot
+LOGS_DIR = os.environ.get('BOLSA_LOGS_DIR', os.path.join(SCRIPTS_DIR, 'logs_bolsa'))
+
+# Credenciales de acceso
+USERNAME = os.environ.get('BOLSA_USERNAME', '')
+PASSWORD = os.environ.get('BOLSA_PASSWORD', '')
+
+# URLs y selectores utilizados por el bot
+INITIAL_PAGE_URL = 'https://www.bolsadesantiago.com/plus_acciones_precios'
+TARGET_DATA_PAGE_URL = 'https://www.bolsadesantiago.com/plus_acciones_precios'
+
+USERNAME_SELECTOR = '#username'
+PASSWORD_SELECTOR = '#password'
+LOGIN_BUTTON_SELECTOR = '#kc-login'
+
+API_PRIMARY_DATA_PATTERNS = [
+    'https://www.bolsadesantiago.com/api/RV_ResumenMercado/getAccionesPrecios',
+    'https://www.bolsadesantiago.com/api/Cuenta_Premium/getPremiumAccionesPrecios',
+]
+
+URLS_TO_INSPECT_IN_HAR_FOR_CONTEXT = [
+    'https://www.bolsadesantiago.com/api/Securities/csrfToken',
+    'https://www.bolsadesantiago.com/api/Comunes_User/getEstadoSesionUsuario',
+    'https://www.bolsadesantiago.com/api/Indices/getIndicesPremium',
+]
+
+MIS_CONEXIONES_TITLE_SELECTOR = "h1:has-text('MIS CONEXIONES')"
+CERRAR_TODAS_SESIONES_SELECTOR = "button:has-text('Cerrar sesión en todos los dispositivos')"
+
+# Carpeta base de logs para la ejecución del bot
+LOG_DIR = os.path.join(SCRIPTS_DIR, 'logs_bolsa')
+os.makedirs(LOG_DIR, exist_ok=True)

--- a/src/scripts/bolsa_santiago_bot.py
+++ b/src/scripts/bolsa_santiago_bot.py
@@ -6,47 +6,40 @@ from datetime import datetime
 import os
 import random
 
+from src.config import (
+    LOG_DIR,
+    INITIAL_PAGE_URL,
+    TARGET_DATA_PAGE_URL,
+    USERNAME,
+    PASSWORD,
+    USERNAME_SELECTOR,
+    PASSWORD_SELECTOR,
+    LOGIN_BUTTON_SELECTOR,
+    API_PRIMARY_DATA_PATTERNS,
+    URLS_TO_INSPECT_IN_HAR_FOR_CONTEXT,
+    MIS_CONEXIONES_TITLE_SELECTOR,
+    CERRAR_TODAS_SESIONES_SELECTOR,
+)
+
 # Importar la función de análisis del otro archivo
 from har_analyzer import analyze_har_and_extract_data
 
 # --- Configuración de Logging Global ---
-LOG_DIR = "logs_bolsa"
-os.makedirs(LOG_DIR, exist_ok=True)
-LOG_FILENAME = "" 
-HAR_FILENAME = "" 
-OUTPUT_ACCIONES_DATA_FILENAME = "" 
-ANALYZED_SUMMARY_FILENAME = "" 
+LOG_FILENAME = ""
+HAR_FILENAME = ""
+OUTPUT_ACCIONES_DATA_FILENAME = ""
+ANALYZED_SUMMARY_FILENAME = ""
 
 logger_instance_global = logging.getLogger(__name__)
 # --- Fin Configuración de Logging ---
 
 # --- CONFIGURACIÓN ---
-INITIAL_PAGE_URL = "https://www.bolsadesantiago.com/plus_acciones_precios"
-TARGET_DATA_PAGE_URL = "https://www.bolsadesantiago.com/plus_acciones_precios"
-
-USERNAME = os.environ.get("BOLSA_USERNAME")
-PASSWORD = os.environ.get("BOLSA_PASSWORD")
-
+# La mayoría de parámetros estáticos se obtienen desde src.config
+# Verificar que se hayan definido credenciales de acceso
 if not USERNAME or not PASSWORD:
     raise ValueError(
         "Environment variables BOLSA_USERNAME and BOLSA_PASSWORD must be set"
     )
-
-USERNAME_SELECTOR = "#username"
-PASSWORD_SELECTOR = "#password"
-LOGIN_BUTTON_SELECTOR = "#kc-login"
-
-API_PRIMARY_DATA_PATTERNS = [
-    "https://www.bolsadesantiago.com/api/RV_ResumenMercado/getAccionesPrecios",
-    "https://www.bolsadesantiago.com/api/Cuenta_Premium/getPremiumAccionesPrecios"
-]
-URLS_TO_INSPECT_IN_HAR_FOR_CONTEXT = [
-    "https://www.bolsadesantiago.com/api/Securities/csrfToken",
-    "https://www.bolsadesantiago.com/api/Comunes_User/getEstadoSesionUsuario",
-    "https://www.bolsadesantiago.com/api/Indices/getIndicesPremium"
-]
-MIS_CONEXIONES_TITLE_SELECTOR = "h1:has-text('MIS CONEXIONES')"
-CERRAR_TODAS_SESIONES_SELECTOR = "button:has-text('Cerrar sesión en todos los dispositivos')"
 # --- FIN DE LA CONFIGURACIÓN ---
 
 def configure_run_specific_logging(logger_to_configure):

--- a/src/scripts/bolsa_service.py
+++ b/src/scripts/bolsa_service.py
@@ -7,15 +7,11 @@ from datetime import datetime
 import threading
 import re
 import glob
-import random # Asegurarse de que random esté importado
+import random  # Asegurarse de que random esté importado
 
-# Configuración de rutas obtenidas desde variables de entorno
-SCRIPTS_DIR = os.environ.get("BOLSA_SCRIPTS_DIR")
-if not SCRIPTS_DIR:
-    raise ValueError("Environment variable BOLSA_SCRIPTS_DIR must be set")
+from src.config import SCRIPTS_DIR, LOGS_DIR
 
-LOGS_DIR = os.environ.get("BOLSA_LOGS_DIR", os.path.join(SCRIPTS_DIR, "logs_bolsa"))
-
+# Rutas de trabajo obtenidas desde el módulo de configuración
 # Configuración de logging para este script de servicio/orquestador
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)


### PR DESCRIPTION
## Summary
- centralize static and environment configuration in `src/config.py`
- pull config into `bolsa_service` and `bolsa_santiago_bot`
- document the new configuration approach in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68430e0d2bd88330bfff025c7654f059