### PR TITLE
Remove csrf token url from inspection list

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -27,7 +27,6 @@ API_PRIMARY_DATA_PATTERNS = [
 ]
 
 URLS_TO_INSPECT_IN_HAR_FOR_CONTEXT = [
-    'https://www.bolsadesantiago.com/api/Securities/csrfToken',
     'https://www.bolsadesantiago.com/api/Comunes_User/getEstadoSesionUsuario',
     'https://www.bolsadesantiago.com/api/Indices/getIndicesPremium',
 ]


### PR DESCRIPTION
## Summary
- clean up config: stop inspecting the CSRF token request in HAR

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843201038f48330a918d87dd2d5113b