### PR TITLE
Ignore CSRF token endpoint in HAR analyzer

### DIFF
--- a/har_analyzer.py
+++ b/har_analyzer.py
@@ -28,6 +28,9 @@ def analyze_har_and_extract_data(har_filepath, primary_api_url_patterns, other_u
         
         for entry_index, entry in enumerate(entries):
             request_url = entry.get("request", {}).get("url", "")
+            if "https://www.bolsadesantiago.com/api/Securities/csrfToken" in request_url:
+                effective_logger.debug(f"HAR: Ignorando solicitud CSRF token (Entrada #{entry_index}): {request_url}")
+                continue
             response_content = entry.get("response", {}).get("content", {})
             response_text = response_content.get("text", "") 
             response_text = response_text or "" 

--- a/src/scripts/har_analyzer.py
+++ b/src/scripts/har_analyzer.py
@@ -28,6 +28,9 @@ def analyze_har_and_extract_data(har_filepath, primary_api_url_patterns, other_u
         
         for entry_index, entry in enumerate(entries):
             request_url = entry.get("request", {}).get("url", "")
+            if "https://www.bolsadesantiago.com/api/Securities/csrfToken" in request_url:
+                effective_logger.debug(f"HAR: Ignorando solicitud CSRF token (Entrada #{entry_index}): {request_url}")
+                continue
             response_content = entry.get("response", {}).get("content", {})
             response_text = response_content.get("text", "") 
             response_text = response_text or "" 


### PR DESCRIPTION
## Summary
- filter out `/api/Securities/csrfToken` from HAR analysis logs

## Testing
- `python -m py_compile har_analyzer.py src/scripts/har_analyzer.py src/scripts/bolsa_santiago_bot.py src/scripts/bolsa_service.py src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6843285edd98833094bb309ce3669ca5