### PR TITLE
Add session countdown to frontend

### DIFF
--- a/src/routes/api.py
+++ b/src/routes/api.py
@@ -5,7 +5,14 @@ import json
 from datetime import datetime
 
 # Importar el servicio de bolsa
-from src.scripts.bolsa_service import get_latest_data, filter_stocks, run_bolsa_bot, start_periodic_updates, stop_periodic_updates
+from src.scripts.bolsa_service import (
+    get_latest_data,
+    filter_stocks,
+    run_bolsa_bot,
+    start_periodic_updates,
+    stop_periodic_updates,
+    get_session_remaining_seconds,
+)
 
 # Crear el blueprint
 api_bp = Blueprint('api', __name__)
@@ -107,6 +114,22 @@ def set_auto_update():
                 "timestamp": datetime.now().strftime("%d/%m/%Y %H:%M:%S")
             }), 400
     
+    except Exception as e:
+        return jsonify({
+            "error": str(e),
+            "timestamp": datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+        }), 500
+
+
+@api_bp.route('/session-time', methods=['GET'])
+def session_time():
+    """Devuelve el tiempo restante de la sesión, si está disponible."""
+    try:
+        remaining = get_session_remaining_seconds()
+        return jsonify({
+            "remaining_seconds": remaining,
+            "timestamp": datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+        })
     except Exception as e:
         return jsonify({
             "error": str(e),

--- a/src/scripts/bolsa_service.py
+++ b/src/scripts/bolsa_service.py
@@ -80,6 +80,44 @@ def extract_timestamp_from_filename(filename):
         logger.exception(f"Error al extraer timestamp del nombre de archivo '{filename}': {e}")
         return datetime.now().strftime("%d/%m/%Y %H:%M:%S") # Fallback a ahora
 
+def get_latest_summary_file():
+    """Devuelve la ruta al resumen HAR más reciente generado por el bot."""
+    try:
+        pattern = os.path.join(LOGS_DIR, "network_summary_*.json")
+        summary_files = glob.glob(pattern)
+
+        if not summary_files:
+            logger.warning(f"No se encontraron archivos 'network_summary_*.json' en {LOGS_DIR}")
+            return None
+
+        latest_summary = max(summary_files, key=os.path.getmtime)
+        logger.info(f"Archivo de resumen HAR más reciente encontrado: {latest_summary}")
+        return latest_summary
+
+    except Exception as e:
+        logger.exception(f"Error al buscar el archivo de resumen HAR más reciente: {e}")
+        return None
+
+def get_session_remaining_seconds():
+    """Obtiene los segundos restantes de la sesión desde el resumen HAR más reciente."""
+    try:
+        summary_path = get_latest_summary_file()
+        if not summary_path or not os.path.exists(summary_path):
+            return None
+
+        with open(summary_path, 'r', encoding='utf-8') as f:
+            summary_data = json.load(f)
+
+        if isinstance(summary_data, list):
+            for entry in summary_data:
+                if isinstance(entry, dict) and "session_remaining_seconds" in entry:
+                    return int(entry["session_remaining_seconds"])
+
+        return None
+    except Exception as e:
+        logger.exception(f"Error al obtener los segundos restantes de la sesión: {e}")
+        return None
+
 def run_bolsa_bot():
     """
     Ejecuta el script bolsa_santiago_bot.py y devuelve la ruta al archivo JSON de datos generado.

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -106,7 +106,10 @@
                     <div class="card-footer text-muted small">
                         <div class="d-flex justify-content-between">
                             <div>Datos obtenidos de la Bolsa de Santiago</div>
-                            <div id="nextUpdateInfo"></div>
+                            <div>
+                                <span id="sessionCountdown" class="me-3"></span>
+                                <span id="nextUpdateInfo"></span>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- support reading latest HAR summary to get remaining session seconds
- expose `/api/session-time` endpoint
- show session countdown in page footer
- update JS to fetch session time and display countdown

## Testing
- `python -m py_compile src/scripts/bolsa_service.py src/routes/api.py`
- `node --check src/static/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68432b87bddc83308282245eab7cf572