### PR TITLE
Add non-interactive mode for bolsa bot

### DIFF
--- a/src/scripts/bolsa_santiago_bot.py
+++ b/src/scripts/bolsa_santiago_bot.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 import os
 import random
+import argparse
 
 from src.config import (
     LOG_DIR,
@@ -32,6 +33,9 @@ OUTPUT_ACCIONES_DATA_FILENAME = ""
 ANALYZED_SUMMARY_FILENAME = ""
 # Timestamp para nombrar archivos generados en cada ejecución
 TIMESTAMP_NOW = ""
+
+# Controla si el script se ejecuta en modo no interactivo
+NON_INTERACTIVE = os.getenv("BOLSA_NON_INTERACTIVE") == "1"
 
 logger_instance_global = logging.getLogger(__name__)
 # --- Fin Configuración de Logging ---
@@ -84,8 +88,11 @@ def handle_console_message(msg, logger_param):
         logger_param.info(f"JS CONSOLE ({msg.type}): {text}")
 
 
-def run_automation(logger_param, attempt=1, max_attempts=2):
-    current_har_filename = HAR_FILENAME 
+def run_automation(logger_param, attempt=1, max_attempts=2, *, non_interactive=None):
+    if non_interactive is None:
+        non_interactive = NON_INTERACTIVE or os.getenv("BOLSA_NON_INTERACTIVE") == "1"
+
+    current_har_filename = HAR_FILENAME
     current_output_acciones_data_filename = OUTPUT_ACCIONES_DATA_FILENAME
     current_analyzed_summary_filename = ANALYZED_SUMMARY_FILENAME
 
@@ -227,24 +234,43 @@ def run_automation(logger_param, attempt=1, max_attempts=2):
 
         logger_param.info("Proceso del script realmente finalizado.")
         if not is_mis_conexiones_page or attempt >= max_attempts:
-            try:
-                input(
-                    "Presiona Enter para terminar el script (después del análisis HAR). El navegador permanecerá abierto."
-                )
-                logger_param.info(
-                    "El navegador no se cerrará automáticamente. Ciérrelo manualmente cuando ya no lo necesite."
-                )
-            except EOFError:
-                logger_param.warning(
-                    "EOFError al esperar la confirmación del usuario. Manteniendo el navegador abierto indefinidamente."
-                )
-                logger_param.info(
-                    "El script está esperando indefinidamente a que el usuario cierre el navegador manualmente."
-                )
-                while True:
-                    time.sleep(60)
+            if non_interactive:
+                logger_param.info("Ejecución no interactiva: finalizando sin esperar entrada del usuario.")
+            else:
+                try:
+                    input(
+                        "Presiona Enter para terminar el script (después del análisis HAR). El navegador permanecerá abierto."
+                    )
+                    logger_param.info(
+                        "El navegador no se cerrará automáticamente. Ciérrelo manualmente cuando ya no lo necesite."
+                    )
+                except EOFError:
+                    logger_param.warning(
+                        "EOFError al esperar la confirmación del usuario. Manteniendo el navegador abierto indefinidamente."
+                    )
+                    logger_param.info(
+                        "El script está esperando indefinidamente a que el usuario cierre el navegador manualmente."
+                    )
+                    while True:
+                        time.sleep(60)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Bolsa Santiago bot")
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="No esperar confirmación del usuario al finalizar",
+    )
+    args = parser.parse_args(argv)
+
+    global NON_INTERACTIVE
+    if args.non_interactive:
+        NON_INTERACTIVE = True
+
+    configure_run_specific_logging(logger_instance_global)
+    run_automation(logger_instance_global, non_interactive=NON_INTERACTIVE)
 
 
 if __name__ == "__main__":
-    configure_run_specific_logging(logger_instance_global) 
-    run_automation(logger_instance_global)
+    main()

--- a/src/scripts/bolsa_service.py
+++ b/src/scripts/bolsa_service.py
@@ -130,11 +130,15 @@ def run_bolsa_bot():
         # las importaciones relativas funcionen correctamente
         logger.info(
             f"Ejecutando: python -m {module_path} en el directorio {BASE_DIR}")
+        env = os.environ.copy()
+        env["BOLSA_NON_INTERACTIVE"] = "1"
+
         process = subprocess.run(
             [sys.executable, "-m", module_path],
             capture_output=True,  # Captura stdout y stderr
             text=True,
             cwd=BASE_DIR,  # Directorio de trabajo para el script
+            env=env,
             check=False  # No lanzar excepción si el script falla, lo manejamos con returncode
         )
         

--- a/tests/test_session_restart.py
+++ b/tests/test_session_restart.py
@@ -81,7 +81,12 @@ def test_restart_after_closing_sessions(monkeypatch):
     monkeypatch.setattr(bot, "sync_playwright", lambda: dummy_playwright)
     monkeypatch.setattr(bot, "analyze_har_and_extract_data", lambda *a, **k: None)
     monkeypatch.setattr(bot, "configure_run_specific_logging", lambda *a, **k: None)
-    monkeypatch.setattr(builtins, "input", lambda *a, **k: "")
+    monkeypatch.setenv("BOLSA_NON_INTERACTIVE", "1")
+
+    def forbid_input(*args, **kwargs):
+        raise AssertionError("input should not be called")
+
+    monkeypatch.setattr(builtins, "input", forbid_input)
 
     logger = mock.Mock()
     bot.run_automation(logger, max_attempts=2)
@@ -92,6 +97,8 @@ def test_restart_after_closing_sessions(monkeypatch):
 
 def test_keep_browser_alive_on_eof(monkeypatch):
     attempt_ref = [0]
+
+    monkeypatch.delenv("BOLSA_NON_INTERACTIVE", raising=False)
 
     dummy_playwright = DummyPlaywright(attempt_ref)
     monkeypatch.setattr(bot, "sync_playwright", lambda: dummy_playwright)


### PR DESCRIPTION
## Summary
- add command line parser and environment variable to skip waiting for input in `bolsa_santiago_bot`
- set `BOLSA_NON_INTERACTIVE=1` when launching the bot from `bolsa_service`
- update tests to use the new flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433e18bf508330b939409a14d9ad3e