### PR TITLE
Add stock price CRUD endpoints and UI

### DIFF
--- a/src/models/stock_price.py
+++ b/src/models/stock_price.py
@@ -12,6 +12,15 @@ class StockPrice(db.Model):
     variation = db.Column(db.Float)
     timestamp = db.Column(db.DateTime, nullable=False, index=True)
 
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'symbol': self.symbol,
+            'price': self.price,
+            'variation': self.variation,
+            'timestamp': self.timestamp.isoformat() if self.timestamp else None,
+        }
+
 
 @event.listens_for(StockPrice.__table__, 'after_create')
 def create_timescale_hypertable(target, connection, **kw):

--- a/src/static/historico.html
+++ b/src/static/historico.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Histórico de Precios</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+<div class="container py-4">
+    <h1 class="mb-4">Histórico de Precios</h1>
+
+    <form id="priceForm" class="row g-3 mb-4">
+        <div class="col-md-3">
+            <input name="symbol" class="form-control" placeholder="Símbolo" required>
+        </div>
+        <div class="col-md-2">
+            <input name="price" type="number" step="0.01" class="form-control" placeholder="Precio" required>
+        </div>
+        <div class="col-md-2">
+            <input name="variation" type="number" step="0.01" class="form-control" placeholder="Variación">
+        </div>
+        <div class="col-md-3">
+            <input name="timestamp" type="datetime-local" class="form-control" required>
+        </div>
+        <div class="col-md-2">
+            <button type="submit" class="btn btn-primary w-100">Guardar</button>
+        </div>
+    </form>
+
+    <table id="pricesTable" class="table table-striped">
+        <thead class="table-dark">
+            <tr>
+                <th>ID</th>
+                <th>Símbolo</th>
+                <th>Precio</th>
+                <th>Variación</th>
+                <th>Fecha</th>
+                <th>Acciones</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/historico.js"></script>
+</body>
+</html>

--- a/src/static/historico.js
+++ b/src/static/historico.js
@@ -1,0 +1,68 @@
+// CRUD operations for stock_prices
+
+document.addEventListener('DOMContentLoaded', () => {
+    loadPrices();
+
+    const form = document.getElementById('priceForm');
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const id = form.dataset.id;
+        const data = {
+            symbol: form.symbol.value,
+            price: parseFloat(form.price.value || 0),
+            variation: parseFloat(form.variation.value || 0),
+            timestamp: form.timestamp.value
+        };
+        let url = '/api/prices';
+        let method = 'POST';
+        if (id) {
+            url += `/${id}`;
+            method = 'PUT';
+        }
+        await fetch(url, {
+            method,
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(data)
+        });
+        form.reset();
+        delete form.dataset.id;
+        loadPrices();
+    });
+});
+
+async function loadPrices() {
+    const tbody = document.querySelector('#pricesTable tbody');
+    tbody.innerHTML = '';
+    const res = await fetch('/api/prices?limit=100');
+    const data = await res.json();
+    data.forEach(p => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td>${p.id}</td>
+            <td>${p.symbol}</td>
+            <td>${p.price}</td>
+            <td>${p.variation ?? ''}</td>
+            <td>${p.timestamp}</td>
+            <td>
+                <button class="btn btn-sm btn-primary" onclick="editPrice(${p.id})">Editar</button>
+                <button class="btn btn-sm btn-danger" onclick="deletePrice(${p.id})">Eliminar</button>
+            </td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+async function editPrice(id) {
+    const res = await fetch(`/api/prices/${id}`);
+    const data = await res.json();
+    const form = document.getElementById('priceForm');
+    form.symbol.value = data.symbol;
+    form.price.value = data.price;
+    form.variation.value = data.variation ?? '';
+    form.timestamp.value = data.timestamp.slice(0,19);
+    form.dataset.id = data.id;
+}
+
+async function deletePrice(id) {
+    await fetch(`/api/prices/${id}`, { method: 'DELETE' });
+    loadPrices();
+}


### PR DESCRIPTION
## Summary
- add `to_dict` helper for `StockPrice`
- implement `/api/prices` CRUD routes
- provide new `historico.html` page
- add `historico.js` to manage price records in the UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68439ee0e2ec8330b7016db3b5a47e12