### PR TITLE
Add user blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ bolsa_app/
 ├── src/
 │   ├── models/            # Modelos de datos (no utilizados en esta versión)
 │   ├── routes/            # Rutas de la API
-│   │   └── api.py         # Endpoints de la API
+│   │   ├── api.py         # Endpoints de acciones
+│   │   └── user.py        # Endpoints de usuarios
 │   ├── scripts/           # Scripts de servicio
 │   │   ├── __init__.py
 │   │   └── bolsa_service.py  # Servicio para gestionar datos de acciones
@@ -163,6 +164,17 @@ Antes de ejecutar la aplicación se deben definir las siguientes variables de en
 - Los datos se almacenan en PostgreSQL/TimescaleDB y se notifican mediante SocketIO
 - La aplicación detecta automáticamente la estructura del JSON y normaliza los campos
 - El analizador HAR también revisa la respuesta de `getEstadoSesionUsuario` y, si contiene fecha o duración de expiración, calcula el tiempo restante de la sesión.
+
+## API de Usuarios
+
+Los endpoints para gestionar usuarios se encuentran bajo la ruta `/api/users`.
+Las operaciones disponibles incluyen:
+
+- `GET /api/users` para obtener todos los usuarios.
+- `POST /api/users` para crear un usuario nuevo.
+- `GET /api/users/<id>` para consultar un usuario por su identificador.
+- `PUT /api/users/<id>` para actualizarlo.
+- `DELETE /api/users/<id>` para eliminarlo.
 
 ## Solución de Problemas
 

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 # Importar blueprints
 from src.routes.api import api_bp
+from src.routes.user import user_bp
 
 # Crear la aplicación Flask
 app = Flask(__name__)
@@ -23,6 +24,7 @@ socketio.init_app(app, cors_allowed_origins="*")
 
 # Registrar blueprints
 app.register_blueprint(api_bp, url_prefix='/api')
+app.register_blueprint(user_bp, url_prefix='/api')
 
 # Ruta principal que sirve el frontend
 @app.route('/', defaults={'path': ''})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+# Use in-memory SQLite for tests to avoid external DB
+os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')

--- a/tests/test_user_endpoints.py
+++ b/tests/test_user_endpoints.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Ensure database is sqlite for tests
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+from src import main
+from src.models import db
+from src.models.user import User
+
+@pytest.fixture
+def app():
+    app = main.app
+    with app.app_context():
+        User.__table__.create(db.engine, checkfirst=True)
+    yield app
+
+
+def test_get_users_endpoint(app):
+    client = app.test_client()
+    resp = client.get('/api/users')
+    assert resp.status_code == 200
+


### PR DESCRIPTION
## Summary
- register the user blueprint in `src/main.py`
- document `/api/users` endpoints in README
- add test to verify `/api/users` responds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68439ed927f88330a755f82f14ee070c