### PR TITLE
Update README and add Playwright CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          playwright install
+      - name: Run tests
+        run: pytest -q
+

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Antes de ejecutar la aplicación se deben definir las siguientes variables de en
    # En Linux/Mac:
    source venv/bin/activate
    
-   # Instalar dependencias
-   pip install -r requirements.txt
+   # Instalar dependencias y Playwright
+   pip install -r requirements.txt && playwright install
    # Iniciar TimescaleDB con docker-compose
    docker-compose up -d db
    ```


### PR DESCRIPTION
## Summary
- show how to install Playwright in README
- add GitHub Actions workflow that installs Playwright before tests

## Testing
- `pip install -r requirements.txt`
- `playwright install --with-deps chromium`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68439ee44ca48330a6c448417f2b195b