### PR TITLE
Add analysis page and sample data table

### DIFF
--- a/src/static/analisis.html
+++ b/src/static/analisis.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Análisis</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+    <div class="container py-4">
+        <h1 class="mb-4">Análisis</h1>
+        <p>Próximamente encontrarás herramientas avanzadas para analizar los datos históricos. Algunas ideas en desarrollo incluyen:</p>
+        <ul>
+            <li>Gráficos comparativos de rendimiento</li>
+            <li>Alertas personalizadas de precios</li>
+            <li>Proyecciones de tendencias</li>
+            <li>Integración de indicadores técnicos</li>
+        </ul>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/static/historico.html
+++ b/src/static/historico.html
@@ -42,6 +42,32 @@
         </thead>
         <tbody></tbody>
     </table>
+
+    <h2 class="mt-5">Ejemplo de visualización</h2>
+    <table class="table table-bordered">
+        <thead class="table-light">
+            <tr>
+                <th>Símbolo</th>
+                <th>Precio</th>
+                <th>Variación</th>
+                <th>Fecha</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>COPEC</td>
+                <td>1234.56</td>
+                <td class="text-success">+1.2%</td>
+                <td>2025-06-01 12:00</td>
+            </tr>
+            <tr>
+                <td>FALABELLA</td>
+                <td>987.65</td>
+                <td class="text-danger">-0.8%</td>
+                <td>2025-06-01 12:00</td>
+            </tr>
+        </tbody>
+    </table>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -9,6 +9,21 @@
     <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="/index.html">Bolsa App</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav">
+                    <li class="nav-item"><a class="nav-link" href="/index.html">Inicio</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/historico.html">Histórico</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/analisis.html">Análisis</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
     <div class="container-fluid py-4">
         <div class="row justify-content-center">
             <div class="col-12 col-lg-10">


### PR DESCRIPTION
## Summary
- create new `analisis.html` page with placeholder suggestions
- show example data table in `historico.html`
- add Bootstrap navbar linking pages in `index.html`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b2c45ef883308956b3957cce9a0e