### PR TITLE
Add navbar to historic and analysis pages

### DIFF
--- a/src/static/analisis.html
+++ b/src/static/analisis.html
@@ -5,9 +5,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Análisis</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="/index.html">Bolsa App</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav">
+                    <li class="nav-item"><a class="nav-link" href="/index.html">Inicio</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/historico.html">Histórico</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/analisis.html">Análisis</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
     <div class="container py-4">
         <h1 class="mb-4">Análisis</h1>
         <p>Próximamente encontrarás herramientas avanzadas para analizar los datos históricos. Algunas ideas en desarrollo incluyen:</p>

--- a/src/static/historico.html
+++ b/src/static/historico.html
@@ -5,9 +5,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Histórico de Precios</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="/index.html">Bolsa App</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav">
+                    <li class="nav-item"><a class="nav-link" href="/index.html">Inicio</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/historico.html">Histórico</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/analisis.html">Análisis</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
 <div class="container py-4">
     <h1 class="mb-4">Histórico de Precios</h1>
 


### PR DESCRIPTION
## Summary
- bring in font-awesome and bootstrap navbar on historico and analisis pages
- link to Index, Historico and Analisis on each page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_6843b7e06cec8330ade86df7cb3205c5