### PR TITLE
Fix Timescale setup for non-Postgres

### DIFF
--- a/src/models/stock_price.py
+++ b/src/models/stock_price.py
@@ -24,7 +24,10 @@ class StockPrice(db.Model):
 
 @event.listens_for(StockPrice.__table__, 'after_create')
 def create_timescale_hypertable(target, connection, **kw):
-    connection.execute(DDL("CREATE EXTENSION IF NOT EXISTS timescaledb"))
-    connection.execute(
-        DDL("SELECT create_hypertable('stock_prices', 'timestamp', if_not_exists => TRUE)")
-    )
+    if connection.dialect.name == "postgresql":
+        connection.execute(DDL("CREATE EXTENSION IF NOT EXISTS timescaledb"))
+        connection.execute(
+            DDL(
+                "SELECT create_hypertable('stock_prices', 'timestamp', if_not_exists => TRUE)"
+            )
+        )


### PR DESCRIPTION
## Summary
- prevent `CREATE EXTENSION` and hypertable creation when database is not PostgreSQL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b8b0e7348330add0961a2c39e6d6