### PR TITLE
Clean imports and adjust long lines

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,14 +1,17 @@
-import sys
 import os
-from flask import Flask, render_template, send_from_directory
+import sys
+
+# Add project root to Python path for absolute imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from flask import Flask, send_from_directory
 from flask_cors import CORS
 
 from src.extensions import socketio
 from src.models import db
 from src.config import SQLALCHEMY_DATABASE_URI, SQLALCHEMY_TRACK_MODIFICATIONS
 
-# Añadir el directorio raíz al path para importaciones absolutas
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 # Importar blueprints
 from src.routes.api import api_bp
@@ -26,6 +29,7 @@ socketio.init_app(app, cors_allowed_origins="*")
 app.register_blueprint(api_bp, url_prefix='/api')
 app.register_blueprint(user_bp, url_prefix='/api')
 
+
 # Ruta principal que sirve el frontend
 @app.route('/', defaults={'path': ''})
 @app.route('/<path:path>')
@@ -34,10 +38,11 @@ def serve(path):
         return send_from_directory(app.static_folder, path)
     return send_from_directory(app.static_folder, 'index.html')
 
+
 if __name__ == '__main__':
     # Crear directorios necesarios si no existen
-    os.makedirs(os.path.join(os.path.dirname(os.path.dirname(__file__)), "logs"), exist_ok=True)
-    os.makedirs(os.path.join(os.path.dirname(os.path.dirname(__file__)), "data"), exist_ok=True)
+    os.makedirs(os.path.join(BASE_DIR, "logs"), exist_ok=True)
+    os.makedirs(os.path.join(BASE_DIR, "data"), exist_ok=True)
     
     # Iniciar la aplicación con soporte WebSocket
     with app.app_context():

--- a/src/models/stock_price.py
+++ b/src/models/stock_price.py
@@ -1,7 +1,7 @@
-from datetime import datetime
 from sqlalchemy import event, DDL
 
 from . import db
+
 
 class StockPrice(db.Model):
     __tablename__ = 'stock_prices'
@@ -18,7 +18,9 @@ class StockPrice(db.Model):
             'symbol': self.symbol,
             'price': self.price,
             'variation': self.variation,
-            'timestamp': self.timestamp.isoformat() if self.timestamp else None,
+            'timestamp': (
+                self.timestamp.isoformat() if self.timestamp else None
+            ),
         }
 
 
@@ -28,6 +30,7 @@ def create_timescale_hypertable(target, connection, **kw):
         connection.execute(DDL("CREATE EXTENSION IF NOT EXISTS timescaledb"))
         connection.execute(
             DDL(
-                "SELECT create_hypertable('stock_prices', 'timestamp', if_not_exists => TRUE)"
+                "SELECT create_hypertable('stock_prices', 'timestamp', "
+                "if_not_exists => TRUE)"
             )
         )

--- a/src/routes/api.py
+++ b/src/routes/api.py
@@ -1,7 +1,4 @@
 from flask import Blueprint, jsonify, request
-import sys
-import os
-import json
 from datetime import datetime
 
 # Importar el servicio de bolsa
@@ -20,6 +17,7 @@ from src.models import db
 # Crear el blueprint
 api_bp = Blueprint('api', __name__)
 
+
 @api_bp.route('/stocks', methods=['GET'])
 def get_stocks():
     """
@@ -28,16 +26,16 @@ def get_stocks():
     try:
         # Obtener códigos de acciones de los parámetros de consulta
         stock_codes = request.args.getlist('code')
-        
+
         if stock_codes:
             # Filtrar acciones por códigos
             result = filter_stocks(stock_codes)
         else:
             # Obtener todas las acciones
             result = get_latest_data()
-            
+
         return jsonify(result)
-    
+
     except Exception as e:
         return jsonify({
             "error": str(e),
@@ -50,18 +48,19 @@ def update_stocks():
     Endpoint para actualizar manualmente los datos de acciones
     """
     try:
-        # Iniciar la actualización en un hilo separado para no bloquear la respuesta
+        # Iniciar la actualización en un hilo separado para no bloquear la
+        # respuesta
         import threading
         update_thread = threading.Thread(target=run_bolsa_bot)
         update_thread.daemon = True
         update_thread.start()
-        
+
         return jsonify({
             "success": True,
             "message": "Proceso de actualización iniciado",
             "timestamp": datetime.now().strftime("%d/%m/%Y %H:%M:%S")
         })
-    
+
     except Exception as e:
         return jsonify({
             "error": str(e),
@@ -75,15 +74,15 @@ def set_auto_update():
     """
     try:
         data = request.get_json()
-        
+
         if not data or "mode" not in data:
             return jsonify({
                 "error": "Se requiere el parámetro 'mode'",
                 "timestamp": datetime.now().strftime("%d/%m/%Y %H:%M:%S")
             }), 400
-        
+
         mode = data["mode"]
-        
+
         if mode == "off":
             # Detener actualizaciones automáticas
             stop_periodic_updates()
@@ -92,31 +91,35 @@ def set_auto_update():
                 "message": "Actualizaciones automáticas desactivadas",
                 "timestamp": datetime.now().strftime("%d/%m/%Y %H:%M:%S")
             })
-        
+
         elif mode == "1-3":
             # Actualización cada 1-3 minutos
             start_periodic_updates(1, 3)
             return jsonify({
                 "success": True,
-                "message": "Actualizaciones automáticas configuradas (1-3 minutos)",
+                "message": (
+                    "Actualizaciones automáticas configuradas (1-3 minutos)"
+                ),
                 "timestamp": datetime.now().strftime("%d/%m/%Y %H:%M:%S")
             })
-        
+
         elif mode == "1-5":
             # Actualización cada 1-5 minutos
             start_periodic_updates(1, 5)
             return jsonify({
                 "success": True,
-                "message": "Actualizaciones automáticas configuradas (1-5 minutos)",
+                "message": (
+                    "Actualizaciones automáticas configuradas (1-5 minutos)"
+                ),
                 "timestamp": datetime.now().strftime("%d/%m/%Y %H:%M:%S")
             })
-        
+
         else:
             return jsonify({
                 "error": "Modo no válido. Opciones: 'off', '1-3', '1-5'",
                 "timestamp": datetime.now().strftime("%d/%m/%Y %H:%M:%S")
             }), 400
-    
+
     except Exception as e:
         return jsonify({
             "error": str(e),

--- a/tests/test_session_restart.py
+++ b/tests/test_session_restart.py
@@ -1,15 +1,19 @@
 import builtins
 from unittest import mock
-import types
 import os
 import sys
 
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)  # noqa: E402
 
-from src.scripts import bolsa_santiago_bot as bot
-from src.config import MIS_CONEXIONES_TITLE_SELECTOR, CERRAR_TODAS_SESIONES_SELECTOR
+from src.scripts import bolsa_santiago_bot as bot  # noqa: E402
+from src.config import (  # noqa: E402
+    MIS_CONEXIONES_TITLE_SELECTOR,
+    CERRAR_TODAS_SESIONES_SELECTOR,
+)
 
 class DummyLocator:
     def __init__(self, visible=True):
@@ -81,8 +85,16 @@ def test_restart_after_closing_sessions(monkeypatch):
 
     dummy_playwright = DummyPlaywright(attempt_ref)
     monkeypatch.setattr(bot, "sync_playwright", lambda: dummy_playwright)
-    monkeypatch.setattr(bot, "analyze_har_and_extract_data", lambda *a, **k: None)
-    monkeypatch.setattr(bot, "configure_run_specific_logging", lambda *a, **k: None)
+    monkeypatch.setattr(
+        bot,
+        "analyze_har_and_extract_data",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        bot,
+        "configure_run_specific_logging",
+        lambda *a, **k: None,
+    )
     monkeypatch.setenv("BOLSA_NON_INTERACTIVE", "1")
 
     def forbid_input(*args, **kwargs):
@@ -93,7 +105,8 @@ def test_restart_after_closing_sessions(monkeypatch):
     logger = mock.Mock()
     bot.run_automation(logger, max_attempts=2)
 
-    # two attempts should have been performed: one for closing sessions and one for normal flow
+    # two attempts should have been performed: one for closing sessions and
+    # one for normal flow
     assert attempt_ref[0] == 2
 
 
@@ -104,8 +117,16 @@ def test_keep_browser_alive_on_eof(monkeypatch):
 
     dummy_playwright = DummyPlaywright(attempt_ref)
     monkeypatch.setattr(bot, "sync_playwright", lambda: dummy_playwright)
-    monkeypatch.setattr(bot, "analyze_har_and_extract_data", lambda *a, **k: None)
-    monkeypatch.setattr(bot, "configure_run_specific_logging", lambda *a, **k: None)
+    monkeypatch.setattr(
+        bot,
+        "analyze_har_and_extract_data",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        bot,
+        "configure_run_specific_logging",
+        lambda *a, **k: None,
+    )
 
     def raise_eof(*args, **kwargs):
         raise EOFError()

--- a/tests/test_user_endpoints.py
+++ b/tests/test_user_endpoints.py
@@ -2,7 +2,9 @@ import os
 import sys
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)  # noqa: E402
 
 # Ensure database is sqlite for tests
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
@@ -23,4 +25,3 @@ def test_get_users_endpoint(app):
     client = app.test_client()
     resp = client.get('/api/users')
     assert resp.status_code == 200
-


### PR DESCRIPTION
## Summary
- remove unused imports across src and tests
- reformat long comment strings
- break long lines to reduce flake8 E501 complaints

## Testing
- `pytest -q` *(fails: ImportError while importing test module)*

------
https://chatgpt.com/codex/tasks/task_e_6843be589fcc83309bea41ffe1b44df7