### PR TITLE
Add WebSocket workflow tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,19 @@
 import os
+import pytest
 
 # Use in-memory SQLite for tests to avoid external DB
 os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
+
+from src import main
+from src.models import db
+
+
+@pytest.fixture
+def app():
+    """Create Flask app with in-memory database for tests."""
+    app = main.app
+    with app.app_context():
+        db.create_all()
+    yield app
+    with app.app_context():
+        db.drop_all()

--- a/tests/test_stock_websocket.py
+++ b/tests/test_stock_websocket.py
@@ -1,0 +1,74 @@
+import json
+import threading
+import json
+
+import pytest
+
+from src.extensions import socketio
+from src.models.stock_price import StockPrice
+from src.scripts import bolsa_service
+
+
+def test_store_prices_emits_event_and_saves(app, tmp_path):
+    client = socketio.test_client(app)
+    data = {
+        "listaResult": [
+            {
+                "NEMO": "TEST",
+                "PRECIO_CIERRE": 100,
+                "VARIACION": 1.5,
+            }
+        ]
+    }
+    json_path = tmp_path / "acciones-precios-plus_20240101_000000.json"
+    json_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with app.app_context():
+        bolsa_service.store_prices_in_db(str(json_path))
+        prices = StockPrice.query.all()
+
+    assert len(prices) == 1
+    received = client.get_received()
+    assert any(r["name"] == "new_data" for r in received)
+
+
+def test_update_endpoint_triggers_websocket(app, tmp_path, monkeypatch):
+    calls = []
+
+    data = {
+        "listaResult": [
+            {"NEMO": "MOCK", "PRECIO_CIERRE": 50, "VARIACION": 0.1}
+        ]
+    }
+    json_path = tmp_path / "acciones-precios-plus_20240102_000000.json"
+    json_path.write_text(json.dumps(data), encoding="utf-8")
+
+    def fake_run():
+        calls.append(True)
+        bolsa_service.store_prices_in_db(str(json_path))
+        return str(json_path)
+
+    monkeypatch.setattr("src.routes.api.run_bolsa_bot", fake_run)
+
+    class DummyThread:
+        def __init__(self, target, args=(), kwargs=None):
+            self.target = target
+            self.args = args
+            self.kwargs = kwargs or {}
+
+        def start(self):
+            self.target(*self.args, **self.kwargs)
+
+    monkeypatch.setattr(threading, "Thread", DummyThread)
+
+    ws_client = socketio.test_client(app)
+    http_client = app.test_client()
+    resp = http_client.post("/api/stocks/update")
+    assert resp.status_code == 200
+    assert calls
+
+    with app.app_context():
+        assert StockPrice.query.count() == 1
+
+    received = ws_client.get_received()
+    assert any(r["name"] == "new_data" for r in received)


### PR DESCRIPTION
## Summary
- create Flask app fixture in tests
- add tests to verify DB insert triggers websocket update

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d8b698dc8330b3df545489e41d14