### PR TITLE
Add connection test for DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,10 @@ pytest -q
 Al establecer `BOLSA_NON_INTERACTIVE=1` las pruebas podrán ejecutar el bot de forma
 no interactiva.
 
+Para comprobar que la base de datos configurada es accesible se puede ejecutar
+el siguiente comando después de completar la instalación:
+
+```bash
+pytest tests/test_database_connection.py
+```
+

--- a/tests/test_database_connection.py
+++ b/tests/test_database_connection.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+from sqlalchemy import create_engine, text
+
+DB_URL = os.getenv('DATABASE_URL') or os.getenv('SQLALCHEMY_DATABASE_URI')
+
+if not DB_URL:
+    pytest.skip('No database URL configured', allow_module_level=True)
+
+SKIP_SQLITE_MEMORY = DB_URL == 'sqlite:///:memory:'
+
+@pytest.mark.skipif(SKIP_SQLITE_MEMORY, reason="In-memory SQLite used for tests")
+def test_database_connection():
+    """Ensure the configured database is reachable."""
+    engine = create_engine(DB_URL)
+    try:
+        with engine.connect() as conn:
+            result = conn.execute(text('SELECT 1'))
+            assert result.scalar() == 1
+    except Exception as exc:
+        pytest.fail(f"PostgreSQL is unreachable: {exc}")


### PR DESCRIPTION
## Summary
- ensure tests can verify database connectivity
- document how to run the check

## Testing
- `pytest -q`
- `pytest tests/test_database_connection.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68447c4b18788330983c1063335ff4bd