### PR TITLE
Add pytest to requirements and streamline CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
           pip install -r requirements.txt
           playwright install
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ Antes de ejecutar la aplicación se deben definir las siguientes variables de en
    # En Linux/Mac:
    source venv/bin/activate
    
-   # Instalar dependencias
-   pip install -r requirements.txt
-   # Instalar los navegadores de Playwright
+    # Instalar dependencias (incluye pytest)
+    pip install -r requirements.txt
+    # Instalar los navegadores de Playwright
    python -m playwright install
    # Iniciar TimescaleDB con docker-compose
 
@@ -129,7 +129,7 @@ Al usar PowerShell 5.x no está disponible el operador `&&`. Ejecuta cada comand
 ```powershell
 python -m venv venv
 venv\Scripts\activate
-pip install -r requirements.txt
+pip install -r requirements.txt  # incluye pytest
 python -m playwright install
 docker-compose up -d db
 ```
@@ -221,7 +221,7 @@ aplicación. De esta forma no es necesario modificar `src/config.py`.
 
 ## Ejecución de Pruebas
 
-Para ejecutar las pruebas automatizadas de la aplicación:
+Para ejecutar las pruebas automatizadas de la aplicación (todas las dependencias se instalan desde `requirements.txt`, incluido `pytest`):
 
 ```bash
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ SQLAlchemy==2.0.40
 playwright==1.52.0
 flask-socketio==5.3.6
 psycopg2-binary==2.9.9
+pytest


### PR DESCRIPTION
## Summary
- include pytest in `requirements.txt`
- remove manual pytest install from CI
- document new instructions in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d55c71648330beaee5e55d14c571