### PR TITLE
Use CDN for Socket.IO client

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ docker-compose up -d db
 - Los datos se leen directamente desde los archivos JSON generados en la ubicación especificada
 - La actualización automática se gestiona tanto en el servidor como en el cliente
 - Los datos se almacenan en PostgreSQL/TimescaleDB y se notifican mediante SocketIO
+- El cliente web carga la librería de Socket.IO desde un CDN (`https://cdn.socket.io`)
 - La aplicación detecta automáticamente la estructura del JSON y normaliza los campos
 - El analizador HAR también revisa la respuesta de `getEstadoSesionUsuario` y, si contiene fecha o duración de expiración, calcula el tiempo restante de la sesión.
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -146,7 +146,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/socket.io/socket.io.js"></script>
+    <script src="https://cdn.socket.io/4.5.4/socket.io.min.js" crossorigin="anonymous"></script>
     <script src="/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- link Socket.IO from a public CDN
- note the CDN dependency in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f160d2fc8330aa81d6d51e3e4d0b