### PR TITLE
Add interactive flag for bolsa bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Antes de ejecutar la aplicación se deben definir las siguientes variables de en
 - **BOLSA_LOGS_DIR**: (opcional) directorio donde el bot almacenará sus logs y archivos JSON. Si no se especifica se utiliza `logs_bolsa` dentro de la carpeta `src` del proyecto.
 - **DATABASE_URL**: cadena de conexión para PostgreSQL/TimescaleDB. Ejemplo: `postgresql://postgres:postgres@localhost:5432/bolsa`.
 - **BOLSA_NON_INTERACTIVE**: si se establece en `1`, permite ejecutar `bolsa_santiago_bot.py` sin confirmación de usuario. Útil para automatización y pruebas.
+  Para ejecutar el bot de forma interactiva (por ejemplo si se presenta un CAPTCHA),
+  omite esta variable o envíe `{"non_interactive": false}` al endpoint `/api/stocks/update`.
 
 ## Instalación y Ejecución
 
@@ -159,6 +161,7 @@ docker-compose up -d db
 2. **Actualización de Datos**:
    - Hacer clic en "Actualizar" para ejecutar el script bolsa_santiago_bot.py y obtener datos recientes
    - Durante la actualización se muestra un indicador de progreso (puede tardar hasta 20 segundos)
+   - Si es necesario resolver un CAPTCHA manualmente, realiza la petición POST a `/api/stocks/update` enviando `{"non_interactive": false}` para ejecutar el bot de forma interactiva
    - Seleccionar un modo de actualización automática en el desplegable:
      - Desactivado: Sin actualización automática
      - Random 1-3 minutos: Actualización aleatoria entre 1 y 3 minutos
@@ -230,7 +233,8 @@ pytest -q
 ```
 
 Al establecer `BOLSA_NON_INTERACTIVE=1` las pruebas podrán ejecutar el bot de forma
-no interactiva.
+no interactiva. De manera equivalente, puede invocar `/api/stocks/update` con
+`{"non_interactive": true}`.
 
 Para comprobar que la base de datos configurada es accesible se puede ejecutar
 el siguiente comando después de completar la instalación:

--- a/src/routes/api.py
+++ b/src/routes/api.py
@@ -48,11 +48,17 @@ def update_stocks():
     Endpoint para actualizar manualmente los datos de acciones
     """
     try:
+        data = request.get_json(silent=True) or {}
+        non_interactive = data.get("non_interactive", True)
+
         # Iniciar la actualización en un hilo separado para no bloquear la
         # respuesta
         import threading
         app = current_app._get_current_object()
-        update_thread = threading.Thread(target=run_bolsa_bot, kwargs={"app": app})
+        update_thread = threading.Thread(
+            target=run_bolsa_bot,
+            kwargs={"app": app, "non_interactive": non_interactive},
+        )
         update_thread.daemon = True
         update_thread.start()
 

--- a/src/scripts/bolsa_service.py
+++ b/src/scripts/bolsa_service.py
@@ -151,9 +151,18 @@ def get_session_remaining_seconds():
         logger.exception(f"Error al obtener los segundos restantes de la sesión: {e}")
         return None
 
-def run_bolsa_bot(app=None):
-    """
-    Ejecuta el script bolsa_santiago_bot.py y devuelve la ruta al archivo JSON de datos generado.
+def run_bolsa_bot(app=None, *, non_interactive=True):
+    """Ejecuta ``bolsa_santiago_bot.py`` y devuelve la ruta al JSON generado.
+
+    Parameters
+    ----------
+    app : Flask, optional
+        Aplicación a cuyo contexto se asociará la ejecución.
+    non_interactive : bool, optional
+        Si es ``True`` (por defecto), se define la variable de entorno
+        ``BOLSA_NON_INTERACTIVE`` para que el bot no solicite confirmaciones
+        manuales. Establécelo en ``False`` para permitir interacción cuando se
+        deba resolver un CAPTCHA.
     """
     ctx = app.app_context() if app else nullcontext()
     with ctx:
@@ -166,7 +175,10 @@ def run_bolsa_bot(app=None):
             logger.info(
                 f"Ejecutando: python -m {module_path} en el directorio {BASE_DIR}")
             env = os.environ.copy()
-            env["BOLSA_NON_INTERACTIVE"] = "1"
+            if non_interactive:
+                env["BOLSA_NON_INTERACTIVE"] = "1"
+            else:
+                env.pop("BOLSA_NON_INTERACTIVE", None)
 
             process = subprocess.run(
                 [sys.executable, "-m", module_path],

--- a/tests/test_stock_websocket.py
+++ b/tests/test_stock_websocket.py
@@ -43,7 +43,7 @@ def test_update_endpoint_triggers_websocket(app, tmp_path, monkeypatch):
     json_path = tmp_path / "acciones-precios-plus_20240102_000000.json"
     json_path.write_text(json.dumps(data), encoding="utf-8")
 
-    def fake_run(app=None):
+    def fake_run(app=None, non_interactive=True):
         calls.append(True)
         with app.app_context():
             bolsa_service.store_prices_in_db(str(json_path), app=app)


### PR DESCRIPTION
## Summary
- allow `run_bolsa_bot` to run interactively when needed
- propagate the option through the `/api/stocks/update` endpoint
- adjust tests for new function signature
- document how to run interactively via API or env variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f4feb7ac83308e0b91ce175b273e