### PR TITLE
Handle captcha pause in automation

### DIFF
--- a/tests/test_captcha_wait.py
+++ b/tests/test_captcha_wait.py
@@ -1,0 +1,95 @@
+import builtins
+from unittest import mock
+
+import pytest
+
+from src.scripts import bolsa_santiago_bot as bot
+
+# Dummy objects for Playwright simulation
+class DummyLocator:
+    def __init__(self, visible=False):
+        self.visible = visible
+    def is_visible(self, timeout=0):
+        return self.visible
+    def click(self):
+        pass
+
+class DummyPage:
+    def __init__(self):
+        self.url = bot.INITIAL_PAGE_URL
+        self.wait_for_function_calls = []
+    def goto(self, url, timeout=None):
+        self.url = url
+    def wait_for_url(self, *a, **k):
+        pass
+    def wait_for_selector(self, *a, **k):
+        pass
+    def fill(self, selector, value):
+        pass
+    def click(self, selector):
+        # Simulate redirection to captcha page after login
+        self.url = "https://radware.example.com/captcha"
+    def content(self):
+        return "captcha page"
+    def wait_for_function(self, js, timeout=0):
+        self.wait_for_function_calls.append((js, timeout))
+    def locator(self, selector):
+        return DummyLocator(False)
+    def wait_for_load_state(self, *a, **k):
+        pass
+    def on(self, *a, **k):
+        pass
+    def reload(self, *a, **k):
+        pass
+    def screenshot(self, *a, **k):
+        pass
+    def is_closed(self):
+        return False
+
+class DummyContext:
+    def __init__(self, page):
+        self.page = page
+    def new_page(self):
+        return self.page
+    def close(self):
+        pass
+
+class DummyBrowser:
+    def __init__(self, page):
+        self.page = page
+    def new_context(self, **kwargs):
+        return DummyContext(self.page)
+    def close(self):
+        pass
+
+class DummyChromium:
+    def __init__(self, page):
+        self.page = page
+    def launch(self, **kwargs):
+        return DummyBrowser(self.page)
+
+class DummyPlaywright:
+    def __init__(self, page):
+        self.chromium = DummyChromium(page)
+    def start(self):
+        return self
+
+
+def test_wait_on_captcha(monkeypatch):
+    page = DummyPage()
+    dummy_playwright = DummyPlaywright(page)
+
+    monkeypatch.setattr(bot, "sync_playwright", lambda: dummy_playwright)
+    monkeypatch.setattr(bot, "analyze_har_and_extract_data", lambda *a, **k: None)
+    monkeypatch.setattr(bot, "configure_run_specific_logging", lambda *a, **k: None)
+    monkeypatch.setattr(bot.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(bot.random, "uniform", lambda a, b: a)
+    monkeypatch.setattr(builtins, "input", lambda *a, **k: "")
+
+    logger = mock.Mock()
+    bot.run_automation(logger, max_attempts=1, non_interactive=False)
+
+    assert page.wait_for_function_calls
+    js, timeout = page.wait_for_function_calls[0]
+    assert "captcha" in js
+    assert timeout == 120000

--- a/tests/test_session_restart.py
+++ b/tests/test_session_restart.py
@@ -32,6 +32,8 @@ class DummyPage:
         pass
     def click(self, selector):
         pass
+    def content(self):
+        return ""
     def locator(self, selector):
         # mis conexiones visible only on first attempt
         if selector == MIS_CONEXIONES_TITLE_SELECTOR:
@@ -45,6 +47,10 @@ class DummyPage:
         pass
     def reload(self, *args, **kwargs):
         pass
+    def screenshot(self, *args, **kwargs):
+        pass
+    def is_closed(self):
+        return False
 
 class DummyContext:
     def __init__(self, attempt_ref):


### PR DESCRIPTION
## Summary
- detect CAPTCHA after attempting login in bolsa_santiago_bot
- pause for user resolution when not running non-interactively
- test captcha wait logic
- update session restart test stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f5032d248330ae2b46f32eb1e5ea