### PR TITLE
Fix interactive flag handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,11 @@ Antes de ejecutar la aplicación se deben definir las siguientes variables de en
 - **DATABASE_URL**: cadena de conexión para PostgreSQL/TimescaleDB. Ejemplo: `postgresql://postgres:postgres@localhost:5432/bolsa`.
 - **BOLSA_NON_INTERACTIVE**: si se establece en `1`, permite ejecutar `bolsa_santiago_bot.py` sin confirmación de usuario. Útil para automatización y pruebas.
   Para ejecutar el bot de forma interactiva (por ejemplo si se presenta un CAPTCHA),
-  omite esta variable o envíe `{"non_interactive": false}` al endpoint `/api/stocks/update`.
-  Si la variable no está definida, al iniciar la aplicación con `python src/main.py` se
-  preguntará si desea habilitar la ejecución no interactiva.
+  omite esta variable o envía `{"non_interactive": false}` al endpoint `/api/stocks/update`.
+  Si el parámetro `non_interactive` no se especifica en el endpoint, se empleará
+  el valor actual de `BOLSA_NON_INTERACTIVE`. Si la variable no está definida, al
+  iniciar la aplicación con `python src/main.py` se preguntará si se desea habilitar
+  la ejecución no interactiva.
 
 ## Instalación y Ejecución
 
@@ -163,7 +165,7 @@ docker-compose up -d db
 2. **Actualización de Datos**:
    - Hacer clic en "Actualizar" para ejecutar el script bolsa_santiago_bot.py y obtener datos recientes
    - Durante la actualización se muestra un indicador de progreso (puede tardar hasta 20 segundos)
-   - Si es necesario resolver un CAPTCHA manualmente, realiza la petición POST a `/api/stocks/update` enviando `{"non_interactive": false}` para ejecutar el bot de forma interactiva
+   - Si es necesario resolver un CAPTCHA manualmente, realiza la petición POST a `/api/stocks/update` enviando `{"non_interactive": false}` para ejecutar el bot de forma interactiva. Si no se incluye este campo, se tomará el valor configurado en `BOLSA_NON_INTERACTIVE`.
    - Seleccionar un modo de actualización automática en el desplegable:
      - Desactivado: Sin actualización automática
      - Random 1-3 minutos: Actualización aleatoria entre 1 y 3 minutos

--- a/src/routes/api.py
+++ b/src/routes/api.py
@@ -49,7 +49,10 @@ def update_stocks():
     """
     try:
         data = request.get_json(silent=True) or {}
-        non_interactive = data.get("non_interactive", True)
+        if "non_interactive" in data:
+            non_interactive = data["non_interactive"]
+        else:
+            non_interactive = None
 
         # Iniciar la actualización en un hilo separado para no bloquear la
         # respuesta

--- a/src/scripts/bolsa_service.py
+++ b/src/scripts/bolsa_service.py
@@ -151,18 +151,19 @@ def get_session_remaining_seconds():
         logger.exception(f"Error al obtener los segundos restantes de la sesión: {e}")
         return None
 
-def run_bolsa_bot(app=None, *, non_interactive=True):
+def run_bolsa_bot(app=None, *, non_interactive=None):
     """Ejecuta ``bolsa_santiago_bot.py`` y devuelve la ruta al JSON generado.
 
     Parameters
     ----------
     app : Flask, optional
         Aplicación a cuyo contexto se asociará la ejecución.
-    non_interactive : bool, optional
-        Si es ``True`` (por defecto), se define la variable de entorno
-        ``BOLSA_NON_INTERACTIVE`` para que el bot no solicite confirmaciones
-        manuales. Establécelo en ``False`` para permitir interacción cuando se
-        deba resolver un CAPTCHA.
+    non_interactive : bool or None, optional
+        Si es ``True`` se define la variable de entorno ``BOLSA_NON_INTERACTIVE``
+        para que el bot no solicite confirmaciones manuales. Si es ``False`` se
+        elimina dicha variable para permitir interacción (por ejemplo para
+        resolver un CAPTCHA). Cuando es ``None`` (valor por defecto) se respeta
+        el valor actual de la variable de entorno y no se modifica.
     """
     ctx = app.app_context() if app else nullcontext()
     with ctx:
@@ -174,6 +175,9 @@ def run_bolsa_bot(app=None, *, non_interactive=True):
             # las importaciones relativas funcionen correctamente
             logger.info(
                 f"Ejecutando: python -m {module_path} en el directorio {BASE_DIR}")
+            if non_interactive is None:
+                non_interactive = os.getenv("BOLSA_NON_INTERACTIVE") == "1"
+
             env = os.environ.copy()
             if non_interactive:
                 env["BOLSA_NON_INTERACTIVE"] = "1"


### PR DESCRIPTION
## Summary
- default interactive setting to existing environment variable
- propagate `non_interactive` parameter only when explicitly provided
- document new behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c2f281a48330814e3fbf8c0155b0