### PR TITLE
Enforce env credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ La aplicación normaliza automáticamente los nombres de los campos para mantene
 
 Antes de ejecutar la aplicación se deben definir las siguientes variables de entorno:
 
-- **BOLSA_USERNAME** y **BOLSA_PASSWORD**: credenciales para iniciar sesión en el sitio de la Bolsa de Santiago.
+- **BOLSA_USERNAME** y **BOLSA_PASSWORD**: credenciales para iniciar sesión en el sitio de la Bolsa de Santiago. Estas credenciales **deben** establecerse como variables de entorno; si no están definidas el bot abortará su ejecución. En `src/config.py` las variables correspondientes tienen un valor vacío por defecto.
 - **BOLSA_SCRIPTS_DIR**: (opcional) ruta al directorio que contiene `bolsa_santiago_bot.py`. Por defecto apunta a la carpeta `src/scripts` del proyecto.
 - **BOLSA_LOGS_DIR**: (opcional) directorio donde el bot almacenará sus logs y archivos JSON. Si no se especifica se utiliza `logs_bolsa` dentro de la carpeta `src` del proyecto.
 - **DATABASE_URL**: cadena de conexión para PostgreSQL/TimescaleDB. Ejemplo: `postgresql://postgres:postgres@localhost:5432/bolsa`.

--- a/src/config.py
+++ b/src/config.py
@@ -11,8 +11,11 @@ LOGS_DIR = os.environ.get('BOLSA_LOGS_DIR', os.path.join(PROJECT_SRC_DIR, 'logs_
 os.makedirs(LOGS_DIR, exist_ok=True)
 
 # Credenciales de acceso
-USERNAME = os.environ.get('BOLSA_USERNAME', 'alcaicey@gmail.com')
-PASSWORD = os.environ.get('BOLSA_PASSWORD', 'Carlosirenee13#')
+# Por defecto se utilizan cadenas vacías. Es obligatorio definirlas mediante las
+# variables de entorno ``BOLSA_USERNAME`` y ``BOLSA_PASSWORD`` antes de ejecutar
+# el bot.
+USERNAME = os.environ.get('BOLSA_USERNAME', '')
+PASSWORD = os.environ.get('BOLSA_PASSWORD', '')
 
 # URLs y selectores utilizados por el bot
 INITIAL_PAGE_URL = 'https://www.bolsadesantiago.com/plus_acciones_precios'

--- a/src/scripts/bolsa_santiago_bot.py
+++ b/src/scripts/bolsa_santiago_bot.py
@@ -42,11 +42,14 @@ logger_instance_global = logging.getLogger(__name__)
 
 # --- CONFIGURACIÓN ---
 # La mayoría de parámetros estáticos se obtienen desde src.config
-# Verificar que se hayan definido credenciales de acceso
-if not USERNAME or not PASSWORD:
-    raise ValueError(
-        "Environment variables BOLSA_USERNAME and BOLSA_PASSWORD must be set"
-    )
+
+def validate_credentials():
+    """Comprueba que las credenciales estén definidas en el entorno."""
+    if not USERNAME or not PASSWORD:
+        raise ValueError(
+            "Missing credentials: set BOLSA_USERNAME and BOLSA_PASSWORD"
+        )
+
 # --- FIN DE LA CONFIGURACIÓN ---
 
 def configure_run_specific_logging(logger_to_configure):
@@ -301,6 +304,7 @@ def main(argv=None):
     if args.non_interactive:
         NON_INTERACTIVE = True
 
+    validate_credentials()
     configure_run_specific_logging(logger_instance_global)
     run_automation(logger_instance_global, non_interactive=NON_INTERACTIVE)
 


### PR DESCRIPTION
## Summary
- don't default username and password to real values
- validate credentials only when running the bot
- document mandatory env vars

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c8814e488330837660932f6199c1