### PR TITLE
Add login with credential storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,10 @@ docker-compose up -d db
 
 3. **Acceso a la aplicación**:
    - Abrir un navegador web
-   - Acceder a `http://localhost:5000`
+   - Visitar `http://localhost:5000/login.html` la primera vez para registrar las credenciales
+   - Ingresar el usuario y contraseña que se utilizarán para el bot. Si se marca
+     "Recordar credenciales" se almacenarán en la base de datos y se cargarán automáticamente en reinicios posteriores.
+   - Tras un inicio exitoso se redirige a `index.html`. Si las credenciales ya están guardadas se puede acceder directamente a `http://localhost:5000`.
 
 ## Uso de la Aplicación
 

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from flask_cors import CORS
 
 from src.extensions import socketio
 from src.models import db
+from src.models.credentials import Credential
 from src.config import SQLALCHEMY_DATABASE_URI, SQLALCHEMY_TRACK_MODIFICATIONS
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -24,6 +25,14 @@ app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = SQLALCHEMY_TRACK_MODIFICATIONS
 CORS(app)  # Habilitar CORS para todas las rutas
 db.init_app(app)
 socketio.init_app(app, cors_allowed_origins="*")
+
+
+def load_saved_credentials():
+    """Carga credenciales desde la base de datos si existen."""
+    cred = Credential.query.first()
+    if cred:
+        os.environ.setdefault("BOLSA_USERNAME", cred.username)
+        os.environ.setdefault("BOLSA_PASSWORD", cred.password)
 
 # Registrar blueprints
 app.register_blueprint(api_bp, url_prefix='/api')
@@ -69,4 +78,5 @@ if __name__ == '__main__':
     # Iniciar la aplicación con soporte WebSocket
     with app.app_context():
         db.create_all()
+        load_saved_credentials()
     socketio.run(app, host='0.0.0.0', port=5000, debug=True)

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,3 +1,9 @@
 from flask_sqlalchemy import SQLAlchemy
 
+# Base de datos
 db = SQLAlchemy()
+
+# Import models to ensure they are registered with SQLAlchemy
+from .user import User  # noqa: E402,F401
+from .stock_price import StockPrice  # noqa: E402,F401
+from .credentials import Credential  # noqa: E402,F401

--- a/src/models/credentials.py
+++ b/src/models/credentials.py
@@ -1,0 +1,14 @@
+from . import db
+
+class Credential(db.Model):
+    __tablename__ = 'credentials'
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(255), nullable=False)
+    password = db.Column(db.String(255), nullable=False)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'username': self.username,
+            'password': self.password,
+        }

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -398,6 +398,13 @@ function loadStockCodes() {
 
 // Event Listeners
 document.addEventListener('DOMContentLoaded', () => {
+    fetch('/api/credentials')
+        .then(r => r.json())
+        .then(data => {
+            if (!data.has_credentials) {
+                window.location.href = '/login.html';
+            }
+        });
     // Conectar con el servidor vía WebSocket
     const socket = io();
     socket.on('new_data', () => {

--- a/src/static/login.html
+++ b/src/static/login.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+    <div class="container py-5">
+        <div class="row justify-content-center">
+            <div class="col-md-6">
+                <div class="card shadow">
+                    <div class="card-header bg-primary text-white">
+                        <h1 class="h5 mb-0">Iniciar Sesión</h1>
+                    </div>
+                    <div class="card-body">
+                        <form id="loginForm">
+                            <div class="mb-3">
+                                <label class="form-label">Usuario</label>
+                                <input type="text" id="username" class="form-control" required>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Contraseña</label>
+                                <input type="password" id="password" class="form-control" required>
+                            </div>
+                            <div class="form-check mb-3">
+                                <input class="form-check-input" type="checkbox" id="remember">
+                                <label class="form-check-label" for="remember">Recordar credenciales</label>
+                            </div>
+                            <button type="submit" class="btn btn-primary w-100">Ingresar</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script src="/login.js"></script>
+</body>
+</html>

--- a/src/static/login.js
+++ b/src/static/login.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', () => {
+    fetch('/api/credentials')
+        .then(r => r.json())
+        .then(data => {
+            if (data.has_credentials) {
+                window.location.href = '/index.html';
+            }
+        });
+
+    const form = document.getElementById('loginForm');
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const username = document.getElementById('username').value.trim();
+        const password = document.getElementById('password').value;
+        const remember = document.getElementById('remember').checked;
+        const resp = await fetch('/api/credentials', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ username, password, remember })
+        });
+        if (resp.ok) {
+            window.location.href = '/index.html';
+        } else {
+            alert('Error al guardar credenciales');
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- introduce Credential model to store bot credentials
- load saved credentials on startup
- expose `/api/credentials` endpoint for status and save
- add login page and script
- redirect to login if credentials missing
- document login workflow in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d39a7cfc83309532dfb81b0efa1e