### PR TITLE
Prevent multiple browser instances in Bolsa bot

### DIFF
--- a/src/routes/api.py
+++ b/src/routes/api.py
@@ -7,6 +7,7 @@ from src.scripts.bolsa_service import (
     get_latest_data,
     filter_stocks,
     run_bolsa_bot,
+    is_bot_running,
     start_periodic_updates,
     stop_periodic_updates,
     get_session_remaining_seconds,
@@ -56,8 +57,14 @@ def update_stocks():
         else:
             non_interactive = None
 
-        # Iniciar la actualización en un hilo separado para no bloquear la
-        # respuesta
+        if is_bot_running():
+            return jsonify({
+                "success": False,
+                "message": "La automatización ya está en ejecución",
+                "timestamp": datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+            })
+
+        # Iniciar la actualización en un hilo separado para no bloquear la respuesta
         import threading
         app = current_app._get_current_object()
         update_thread = threading.Thread(


### PR DESCRIPTION
## Summary
- track bot state in `bolsa_service` to avoid relaunching if running
- skip launching new instances for data refresh or periodic updates when a browser is already open
- expose `is_bot_running` and use it from the update endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6845decdd1a4833098ace5ba3385b844