### PR TITLE
Add column visibility preferences

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -7,3 +7,4 @@ db = SQLAlchemy()
 from .user import User  # noqa: E402,F401
 from .stock_price import StockPrice  # noqa: E402,F401
 from .credentials import Credential  # noqa: E402,F401
+from .column_preference import ColumnPreference  # noqa: E402,F401

--- a/src/models/column_preference.py
+++ b/src/models/column_preference.py
@@ -1,0 +1,12 @@
+from . import db
+
+class ColumnPreference(db.Model):
+    __tablename__ = 'column_preferences'
+    id = db.Column(db.Integer, primary_key=True)
+    columns_json = db.Column(db.Text, nullable=False)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'columns': self.columns_json,
+        }

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -7,6 +7,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-datatables@latest/dist/style.css">
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
@@ -77,6 +78,9 @@
                                     <button type="button" id="refreshBtn" class="btn btn-outline-primary ms-2">
                                         <i class="fas fa-sync-alt me-2"></i>Actualizar
                                     </button>
+                                    <button type="button" id="configColumnsBtn" class="btn btn-outline-secondary ms-2" data-bs-toggle="modal" data-bs-target="#columnConfigModal">
+                                        <i class="fas fa-sliders-h me-2"></i>Configurar
+                                    </button>
                                 </div>
                             </div>
                         </form>
@@ -132,6 +136,27 @@
         </div>
     </div>
 
+    <!-- Modal configuración de columnas -->
+    <div class="modal fade" id="columnConfigModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Seleccionar columnas</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="columnConfigForm" class="row g-2">
+                        <!-- checkboxes inserted by app.js -->
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="button" id="saveColumnPrefs" class="btn btn-primary">Guardar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Spinner de carga mejorado -->
     <div id="loadingOverlay" class="loading-overlay d-none">
         <div class="loading-content">
@@ -147,6 +172,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.socket.io/4.5.4/socket.io.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/simple-datatables@latest" crossorigin="anonymous"></script>
     <script src="/app.js"></script>
 </body>
 </html>

--- a/tests/test_column_preferences.py
+++ b/tests/test_column_preferences.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+from src import main
+from src.models import db
+from src.models.column_preference import ColumnPreference
+
+@pytest.fixture
+def app():
+    app = main.app
+    with app.app_context():
+        ColumnPreference.__table__.create(db.engine, checkfirst=True)
+    yield app
+
+
+def test_column_preferences(app):
+    client = app.test_client()
+    resp = client.get('/api/column-preferences')
+    assert resp.status_code == 200
+    assert resp.get_json()['columns'] is None
+
+    resp = client.post('/api/column-preferences', json={'columns': ['A', 'B']})
+    assert resp.status_code == 200
+
+    resp = client.get('/api/column-preferences')
+    assert resp.get_json()['columns'] == '["A", "B"]'


### PR DESCRIPTION
## Summary
- support saving column visibility to DB
- create model and API routes for preferences
- add simple-datatables for filtering and sorting
- allow configuring visible columns in the UI
- include tests for the new endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e4c3401c8330a64d643b52bcd696