### PR TITLE
Fix column selection refresh bug

### DIFF
--- a/src/static/app.js
+++ b/src/static/app.js
@@ -171,6 +171,11 @@ async function fetchAndDisplayStocks() {
 
 // Función para actualizar la tabla de acciones
 function updateStocksTable(data) {
+    if (dataTable) {
+        dataTable.destroy();
+        dataTable = null;
+    }
+
     const thead = stocksTable.querySelector('thead tr');
     const tbody = stocksTable.querySelector('tbody');
     thead.innerHTML = '';
@@ -228,9 +233,6 @@ function updateStocksTable(data) {
         });
     }
 
-    if (dataTable) {
-        dataTable.destroy();
-    }
     dataTable = new simpleDatatables.DataTable(stocksTable, {
         searchable: true,
         fixedHeight: true,


### PR DESCRIPTION
## Summary
- refresh datatable correctly when columns are updated

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e9b8fb38833084d40b1ea14eeec9