### PR TITLE
Add centralized logging and frontend error reporting

### DIFF
--- a/src/scripts/bolsa_service.py
+++ b/src/scripts/bolsa_service.py
@@ -23,10 +23,8 @@ from src.config import SCRIPTS_DIR, LOGS_DIR, BASE_DIR, PROJECT_SRC_DIR
 # Configuración de logging para este script de servicio/orquestador
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-# Crear directorio de logs para este script si no existe (diferente al de bolsa_santiago_bot.py)
-service_log_dir = os.path.join(PROJECT_SRC_DIR, 'service_logs')
-os.makedirs(service_log_dir, exist_ok=True)
-service_log_file = os.path.join(service_log_dir, "bolsa_service.log")
+# Centralizar logs en la misma carpeta definida en LOGS_DIR
+service_log_file = os.path.join(LOGS_DIR, "bolsa_service.log")
 
 file_handler = logging.FileHandler(service_log_file, encoding='utf-8')
 file_handler.setFormatter(logging.Formatter('[%(levelname)s] %(asctime)s - %(message)s'))

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -7,6 +7,27 @@ let nextUpdateTime = null;
 let updateStatusInterval = null;
 let isUpdating = false;
 
+async function logErrorToServer(message, stack = '', action = '') {
+    try {
+        await fetch('/api/logs', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message, stack, action })
+        });
+    } catch (e) {
+        console.error('Error enviando log al servidor:', e);
+    }
+}
+
+window.addEventListener('error', (e) => {
+    logErrorToServer(e.message || 'Error', e.error ? e.error.stack : '', 'global');
+});
+
+window.addEventListener('unhandledrejection', (e) => {
+    const reason = e.reason || {};
+    logErrorToServer(reason.message || String(reason), reason.stack, 'global');
+});
+
 // Elementos DOM
 const stockFilterForm = document.getElementById('stockFilterForm');
 const stockCodeInputs = document.querySelectorAll('.stock-code');
@@ -164,6 +185,7 @@ async function fetchAndDisplayStocks() {
     } catch (error) {
         console.error('Error al obtener datos:', error);
         updateStatus(`Error al obtener datos: ${error.message}`, true);
+        logErrorToServer(error.message, error.stack, 'fetchAndDisplayStocks');
     } finally {
         toggleLoading(false);
     }
@@ -274,6 +296,7 @@ async function updateStocksData() {
             } catch (error) {
                 console.error('Error al actualizar datos:', error);
                 updateStatus(`Error al actualizar datos: ${error.message}`, true);
+                logErrorToServer(error.message, error.stack, 'updateStocksData');
                 toggleLoading(false);
             } finally {
                 isUpdating = false;
@@ -284,6 +307,7 @@ async function updateStocksData() {
         console.error('Error al actualizar datos:', error);
         updateStatus(`Error al actualizar datos: ${error.message}`, true);
         toggleLoading(false);
+        logErrorToServer(error.message, error.stack, 'updateStocksData');
         isUpdating = false;
     }
 }
@@ -365,6 +389,7 @@ async function setAutoUpdate(mode) {
         console.error('Error al configurar actualización automática:', error);
         updateStatus(`Error al configurar actualización automática: ${error.message}`, true);
         autoUpdateSelect.value = 'off';
+        logErrorToServer(error.message, error.stack, 'setAutoUpdate');
     }
 }
 
@@ -451,6 +476,7 @@ async function fetchSessionTime() {
         }
     } catch (error) {
         console.error('Error al obtener tiempo de sesión:', error);
+        logErrorToServer(error.message, error.stack, 'fetchSessionTime');
     }
 }
 

--- a/src/static/login.js
+++ b/src/static/login.js
@@ -1,3 +1,24 @@
+async function logErrorToServer(message, stack = '', action = '') {
+    try {
+        await fetch('/api/logs', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message, stack, action })
+        });
+    } catch (e) {
+        console.error('Error enviando log al servidor:', e);
+    }
+}
+
+window.addEventListener('error', (e) => {
+    logErrorToServer(e.message || 'Error', e.error ? e.error.stack : '', 'global');
+});
+
+window.addEventListener('unhandledrejection', (e) => {
+    const reason = e.reason || {};
+    logErrorToServer(reason.message || String(reason), reason.stack, 'global');
+});
+
 document.addEventListener('DOMContentLoaded', () => {
     fetch('/api/credentials')
         .then(r => r.json())
@@ -5,6 +26,10 @@ document.addEventListener('DOMContentLoaded', () => {
             if (data.has_credentials) {
                 window.location.href = '/index.html';
             }
+        })
+        .catch(err => {
+            console.error('Error cargando credenciales:', err);
+            logErrorToServer(err.message, err.stack, 'loadCredentials');
         });
 
     const form = document.getElementById('loginForm');
@@ -13,15 +38,22 @@ document.addEventListener('DOMContentLoaded', () => {
         const username = document.getElementById('username').value.trim();
         const password = document.getElementById('password').value;
         const remember = document.getElementById('remember').checked;
-        const resp = await fetch('/api/credentials', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ username, password, remember })
-        });
-        if (resp.ok) {
-            window.location.href = '/index.html';
-        } else {
+        try {
+            const resp = await fetch('/api/credentials', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, password, remember })
+            });
+            if (resp.ok) {
+                window.location.href = '/index.html';
+            } else {
+                alert('Error al guardar credenciales');
+                logErrorToServer('Error al guardar credenciales', '', 'loginSubmit');
+            }
+        } catch (err) {
             alert('Error al guardar credenciales');
+            console.error('Error al enviar credenciales:', err);
+            logErrorToServer(err.message, err.stack, 'loginSubmit');
         }
     });
 });


### PR DESCRIPTION
## Summary
- centralize service logs under `logs_bolsa`
- add backend logger to store frontend error messages
- send error logs from `app.js`
- send error logs from `login.js`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ea36bab08330a5fe54d3e83c88b8