### PR TITLE
Add tracking of last update timestamp in DB

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -9,3 +9,4 @@ from .stock_price import StockPrice  # noqa: E402,F401
 from .credentials import Credential  # noqa: E402,F401
 from .column_preference import ColumnPreference  # noqa: E402,F401
 from .stock_filter import StockFilter  # noqa: E402,F401
+from .last_update import LastUpdate  # noqa: E402,F401

--- a/src/models/last_update.py
+++ b/src/models/last_update.py
@@ -1,0 +1,13 @@
+from . import db
+from datetime import datetime
+
+class LastUpdate(db.Model):
+    __tablename__ = 'last_update'
+    id = db.Column(db.Integer, primary_key=True, default=1)
+    timestamp = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'timestamp': self.timestamp
+        }


### PR DESCRIPTION
## Summary
- create `LastUpdate` model to store latest update time
- update models initialization
- track last update timestamp when storing prices
- serve stock data from DB using latest timestamp

## Testing
- `pytest -q tests/test_store_prices_upsert.py`

------
https://chatgpt.com/codex/tasks/task_e_6845f63c03508330be7a8fcd4e3a05e7