### PR TITLE
Implement fixed CAPTCHA wait

### DIFF
--- a/src/scripts/bolsa_santiago_bot.py
+++ b/src/scripts/bolsa_santiago_bot.py
@@ -180,18 +180,11 @@ def run_automation(logger_param, attempt=1, max_attempts=2, *, non_interactive=N
             captcha_detected = any(ind in lower_content for ind in indicators)
 
         if captcha_detected:
-            logger_param.warning("Posible CAPTCHA detectado. Esperando al usuario si es posible...")
-            if not non_interactive:
-                try:
-                    page.wait_for_function(
-                        "() => !document.body.innerText.toLowerCase().includes('captcha') "
-                        "&& !window.location.href.toLowerCase().includes('radware') "
-                        "&& !window.location.href.toLowerCase().includes('captcha')",
-                        timeout=120000,
-                    )
-                    logger_param.info("Continuando después de la resolución del CAPTCHA")
-                except PlaywrightTimeoutError:
-                    logger_param.warning("Timeout esperando resolución del CAPTCHA, se continúa")
+            logger_param.warning(
+                "Posible CAPTCHA detectado. Esperando 10 segundos para que el usuario realice la acción..."
+            )
+            time.sleep(10)
+            logger_param.info("Continuando después de la espera por CAPTCHA")
 
         logger_param.info("Paso 5: Esperando redirección post-login a www.bolsadesantiago.com...")
         try:

--- a/tests/test_captcha_wait.py
+++ b/tests/test_captcha_wait.py
@@ -82,14 +82,14 @@ def test_wait_on_captcha(monkeypatch):
     monkeypatch.setattr(bot, "sync_playwright", lambda: dummy_playwright)
     monkeypatch.setattr(bot, "analyze_har_and_extract_data", lambda *a, **k: None)
     monkeypatch.setattr(bot, "configure_run_specific_logging", lambda *a, **k: None)
-    monkeypatch.setattr(bot.time, "sleep", lambda *a, **k: None)
+    sleep_calls = []
+    def dummy_sleep(t):
+        sleep_calls.append(t)
+    monkeypatch.setattr(bot.time, "sleep", dummy_sleep)
     monkeypatch.setattr(bot.random, "uniform", lambda a, b: a)
     monkeypatch.setattr(builtins, "input", lambda *a, **k: "")
 
     logger = mock.Mock()
     bot.run_automation(logger, max_attempts=1, non_interactive=False, keep_open=False)
 
-    assert page.wait_for_function_calls
-    js, timeout = page.wait_for_function_calls[0]
-    assert "captcha" in js
-    assert timeout == 120000
+    assert 10 in sleep_calls


### PR DESCRIPTION
## Summary
- adjust CAPTCHA detection to wait 10 seconds
- update tests for new CAPTCHA wait behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461f848f708330a2d6adbaf7445cc5