### PR TITLE
Add missing frontend log endpoint

### DIFF
--- a/src/routes/api.py
+++ b/src/routes/api.py
@@ -37,6 +37,22 @@ if not client_logger.handlers:
 # Crear el blueprint
 api_bp = Blueprint('api', __name__)
 
+# Endpoint to receive log messages from the frontend
+@api_bp.route('/logs', methods=['POST'])
+def store_frontend_log():
+    """Persist log messages sent by the client application."""
+    data = request.get_json(silent=True) or {}
+    message = data.get('message', '')
+    stack = data.get('stack', '')
+    action = data.get('action', 'unknown')
+
+    log_parts = [f"[{action}] {message}"]
+    if stack:
+        log_parts.append(stack)
+    client_logger.info(' | '.join(log_parts))
+
+    return jsonify({"success": True})
+
 
 @api_bp.route('/stocks', methods=['GET'])
 def get_stocks():


### PR DESCRIPTION
## Summary
- add `/api/logs` route to persist client-side logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461e8071488330a7ffd1ac21b80817