### PR TITLE
Handle alt stock keys

### DIFF
--- a/src/scripts/bolsa_service.py
+++ b/src/scripts/bolsa_service.py
@@ -126,10 +126,13 @@ def store_prices_in_db(json_path, app=None):
                 for item in rows:
                     if not isinstance(item, dict):
                         continue
+                    symbol = item.get("NEMO") or item.get("symbol")
+                    price = float(item.get("PRECIO_CIERRE") or item.get("price") or 0)
+                    variation = float(item.get("VARIACION") or item.get("variation") or 0)
                     values = {
-                        "symbol": item.get("NEMO"),
-                        "price": float(item.get("PRECIO_CIERRE", 0) or 0),
-                        "variation": float(item.get("VARIACION", 0) or 0),
+                        "symbol": symbol,
+                        "price": price,
+                        "variation": variation,
                         "timestamp": ts,
                     }
 
@@ -375,11 +378,14 @@ def filter_stocks(stock_codes):
         
         filtered_stocks = []
         for stock in stocks_list:
-            if isinstance(stock, dict) and "NEMO" in stock and isinstance(stock["NEMO"], str):
-                if stock["NEMO"].upper() in stock_codes_upper:
-                    filtered_stocks.append(stock)
+            nemo = stock.get("NEMO") or stock.get("symbol") if isinstance(stock, dict) else None
+            if isinstance(nemo, str) and nemo.upper() in stock_codes_upper:
+                filtered_stocks.append(stock)
             else:
-                logger.warning(f"Elemento de acción con formato inesperado o sin 'NEMO': {str(stock)[:100]}")
+                logger.warning(
+                    "Elemento de acción con formato inesperado o sin 'NEMO/symbol': %s",
+                    str(stock)[:100],
+                )
         
         logger.info(f"Filtradas {len(filtered_stocks)} acciones de {len(stocks_list)} originales.")
         return {

--- a/tests/test_filter_stocks_function.py
+++ b/tests/test_filter_stocks_function.py
@@ -1,0 +1,25 @@
+import pytest
+
+from src.scripts import bolsa_service
+
+
+def test_filter_stocks_with_alternative_keys(monkeypatch):
+    data = {
+        "data": [
+            {"NEMO": "AAA", "price": 1},
+            {"symbol": "BBB", "price": 2},
+            {"symbol": 123},
+            "bad"
+        ],
+        "timestamp": "01/01/2024 00:00:00",
+        "source_file": "dummy.json",
+    }
+
+    monkeypatch.setattr(bolsa_service, "get_latest_data", lambda: data)
+
+    result = bolsa_service.filter_stocks(["AAA", "BBB"])
+
+    assert "error" not in result
+    assert result["count"] == 2
+    symbols = [s.get("NEMO") or s.get("symbol") for s in result["data"]]
+    assert symbols == ["AAA", "BBB"]

--- a/tests/test_store_prices_upsert.py
+++ b/tests/test_store_prices_upsert.py
@@ -20,3 +20,18 @@ def test_store_prices_upsert(app, tmp_path):
         prices = StockPrice.query.all()
 
     assert len(prices) == 1
+
+def test_store_prices_with_alternative_keys(app, tmp_path):
+    data = {"listaResult": [{"symbol": "ALT", "price": 5, "variation": 1.2}]}
+    json_path = tmp_path / "acciones-precios-plus_20240111_000000.json"
+    json_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with app.app_context():
+        bolsa_service.store_prices_in_db(str(json_path))
+        prices = StockPrice.query.all()
+
+    assert len(prices) == 1
+    price = prices[0]
+    assert price.symbol == "ALT"
+    assert price.price == 5.0
+    assert price.variation == 1.2


### PR DESCRIPTION
## Summary
- support alternative keys when storing stock prices in DB
- allow filtering stocks using either `NEMO` or `symbol`
- test filter_stocks() and store_prices_in_db() with alternative keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684621c6b0548330bf070f1b5680c7b3