### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/static/analisis.html
+++ b/src/static/analisis.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="es" data-bs-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -16,11 +16,12 @@
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="navbar-nav">
+                <ul class="navbar-nav me-auto">
                     <li class="nav-item"><a class="nav-link" href="/index.html">Inicio</a></li>
                     <li class="nav-item"><a class="nav-link" href="/historico.html">Histórico</a></li>
                     <li class="nav-item"><a class="nav-link" href="/analisis.html">Análisis</a></li>
                 </ul>
+                <button id="themeToggle" class="btn btn-outline-light ms-lg-3" type="button" aria-label="Toggle theme"></button>
             </div>
         </div>
     </nav>
@@ -35,5 +36,6 @@
         </ul>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/theme.js"></script>
 </body>
 </html>

--- a/src/static/historico.html
+++ b/src/static/historico.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="es" data-bs-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -16,11 +16,12 @@
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="navbar-nav">
+                <ul class="navbar-nav me-auto">
                     <li class="nav-item"><a class="nav-link" href="/index.html">Inicio</a></li>
                     <li class="nav-item"><a class="nav-link" href="/historico.html">Histórico</a></li>
                     <li class="nav-item"><a class="nav-link" href="/analisis.html">Análisis</a></li>
                 </ul>
+                <button id="themeToggle" class="btn btn-outline-light ms-lg-3" type="button" aria-label="Toggle theme"></button>
             </div>
         </div>
     </nav>
@@ -87,6 +88,7 @@
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/theme.js"></script>
 <script src="/historico.js"></script>
 </body>
 </html>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="es" data-bs-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -17,11 +17,12 @@
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="navbar-nav">
+                <ul class="navbar-nav me-auto">
                     <li class="nav-item"><a class="nav-link" href="/index.html">Inicio</a></li>
                     <li class="nav-item"><a class="nav-link" href="/historico.html">Histórico</a></li>
                     <li class="nav-item"><a class="nav-link" href="/analisis.html">Análisis</a></li>
                 </ul>
+                <button id="themeToggle" class="btn btn-outline-light ms-lg-3" type="button" aria-label="Toggle theme"></button>
             </div>
         </div>
     </nav>
@@ -177,6 +178,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.socket.io/4.5.4/socket.io.min.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/simple-datatables@latest" crossorigin="anonymous"></script>
+    <script src="/theme.js"></script>
     <script src="/app.js"></script>
 </body>
 </html>

--- a/src/static/login.html
+++ b/src/static/login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="es" data-bs-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
+    <button id="themeToggle" class="btn btn-outline-secondary position-absolute top-0 end-0 m-3" type="button" aria-label="Toggle theme"></button>
     <div class="container py-5">
         <div class="row justify-content-center">
             <div class="col-md-6">
@@ -36,6 +37,7 @@
             </div>
         </div>
     </div>
+    <script src="/theme.js"></script>
     <script src="/login.js"></script>
 </body>
 </html>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -2,7 +2,8 @@
 
 /* Estilos generales */
 body {
-    background-color: #f8f9fa;
+    background-color: var(--bs-body-bg);
+    color: var(--bs-body-color);
 }
 
 /* Estilos para la tabla */

--- a/src/static/theme.js
+++ b/src/static/theme.js
@@ -1,0 +1,18 @@
+function applyTheme(theme) {
+    document.documentElement.setAttribute('data-bs-theme', theme);
+    localStorage.setItem('theme', theme);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const toggle = document.getElementById('themeToggle');
+    if (!toggle) return;
+    const stored = localStorage.getItem('theme') || 'light';
+    applyTheme(stored);
+    toggle.innerHTML = stored === 'dark' ? '<i class="fas fa-sun"></i>' : '<i class="fas fa-moon"></i>';
+    toggle.addEventListener('click', () => {
+        const current = document.documentElement.getAttribute('data-bs-theme');
+        const next = current === 'dark' ? 'light' : 'dark';
+        applyTheme(next);
+        toggle.innerHTML = next === 'dark' ? '<i class="fas fa-sun"></i>' : '<i class="fas fa-moon"></i>';
+    });
+});


### PR DESCRIPTION
## Summary
- support dark mode selection via button
- remember theme in localStorage

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: test_log_endpoint_requires_message)*

------
https://chatgpt.com/codex/tasks/task_e_684621e8493c83308b1455774a746b38