### PR TITLE
Fix premium data caching

### DIFF
--- a/src/scripts/bolsa_santiago_bot.py
+++ b/src/scripts/bolsa_santiago_bot.py
@@ -141,7 +141,12 @@ def fetch_premium_data(context, logger_param, output_path):
             if "csrf" in c.get("name", "").lower():
                 csrf = c.get("value")
                 break
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            # Asegurar que la API no devuelva una respuesta cacheada
+            "Cache-Control": "no-cache",
+            "Pragma": "no-cache",
+        }
         if csrf:
             headers["X-CSRFToken"] = csrf
 


### PR DESCRIPTION
## Summary
- disable caching for Bolsa API calls in `bolsa_santiago_bot`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684747d122288330ad8b60dde6684c53