### PR TITLE
Document event flows and handle browser refresh

### DIFF
--- a/diagrama_eventos.md
+++ b/diagrama_eventos.md
@@ -1,0 +1,33 @@
+# Flujos principales de la aplicación
+
+Los siguientes diagramas describen de forma simplificada cómo interactúa el usuario con la interfaz web.
+
+## Carga inicial
+```mermaid
+flowchart TD
+    A[Inicio] --> B[Revisar credenciales]
+    B -->|Ok| C[Conectar WebSocket]
+    C --> D[Leer filtros guardados]
+    D --> E[Obtener última actualización]
+    E --> F[Mostrar tabla de acciones]
+```
+
+## Al presionar **Filtrar**
+```mermaid
+flowchart TD
+    A[Click Filtrar] --> B[Enviar códigos al servidor]
+    B --> C[Servidor filtra datos]
+    C --> D[Recibir respuesta]
+    D --> E[Actualizar tabla]
+```
+
+## Al presionar **Actualizar**
+```mermaid
+flowchart TD
+    A[Click Actualizar] --> B{¿Bot en ejecución?}
+    B -- Sí --> C[Enviar ENTER al navegador]
+    C --> D[Esperar datos nuevos]
+    B -- No --> E[Lanzar bot]
+    E --> D
+    D --> F[Refrescar tabla]
+```

--- a/flujo_fallos.md
+++ b/flujo_fallos.md
@@ -1,0 +1,20 @@
+# Flujo de fallos y recuperaciones
+
+Estos diagramas muestran cómo maneja la aplicación los posibles errores.
+
+```mermaid
+flowchart TD
+    A[Iniciar sesión] --> B{Credenciales válidas?}
+    B -- No --> C[Mostrar error]
+    B -- Sí --> D[Intentar navegar]
+    D --> E{¿Error de red?}
+    E -- Sí --> F[Reintentar]
+    F --> D
+    E -- No --> G[Esperar XHR]
+    G --> H{¿Respuesta recibida?}
+    H -- No --> I[Fallback a captura HAR]
+    I --> J{¿Código 403?}
+    H -- Sí --> J
+    J -- Sí --> K[Notificar acceso restringido]
+    J -- No --> L[Procesar datos]
+```


### PR DESCRIPTION
## Summary
- add `diagrama_eventos.md` with Mermaid diagrams of user flows
- add `flujo_fallos.md` with error-handling flow
- log last_update changes when refreshing data or storing results
- allow auto-detection of Flask app when sending ENTER to browser

## Testing
- `pytest tests/test_refresh_running_bot.py::test_update_when_bot_running_triggers_enter tests/test_refresh_running_bot.py::test_update_restarts_when_enter_fails -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684771a978408330880317061f4b21a9