### PR TITLE
Mejoras a refresco de datos y vista histórica

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -55,6 +55,8 @@ def _signal_handler(signum, frame):
     _cleanup_resources()
     try:
         socketio.stop()
+    except BrokenPipeError:
+        pass
     except Exception as exc:
         print(f"Error al detener SocketIO: {exc}")
     finally:
@@ -125,6 +127,12 @@ if __name__ == "__main__":
         db.create_all()
         load_saved_credentials()
     try:
-        socketio.run(app, host="0.0.0.0", port=5000, debug=True)
+        socketio.run(
+            app,
+            host="0.0.0.0",
+            port=5000,
+            debug=False,
+            use_reloader=False,
+        )
     except KeyboardInterrupt:
         _signal_handler(signal.SIGINT, None)

--- a/src/scripts/bolsa_service.py
+++ b/src/scripts/bolsa_service.py
@@ -640,7 +640,7 @@ def compare_last_two_db_entries():
             else:
                 unchanged.append(curr.to_dict())
 
-        return {
+        result = {
             "current_timestamp": ts_curr.strftime("%d/%m/%Y %H:%M:%S"),
             "previous_timestamp": ts_prev.strftime("%d/%m/%Y %H:%M:%S"),
             "current_file": ts_curr.isoformat(),
@@ -653,6 +653,20 @@ def compare_last_two_db_entries():
             "total_compared": len(curr_map.keys() | prev_map.keys()),
             "change_count": len(changes),
         }
+
+        if changes:
+            diff_file = os.path.join(
+                LOGS_DIR,
+                f"diff_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json",
+            )
+            try:
+                with open(diff_file, "w", encoding="utf-8") as f:
+                    json.dump(changes, f, indent=2, ensure_ascii=False)
+                result["diff_file"] = diff_file
+            except Exception as write_exc:
+                logger.warning(f"No se pudo escribir diff_file: {write_exc}")
+
+        return result
     except Exception as exc:
         logger.exception(f"Error al comparar registros históricos: {exc}")
         return {}

--- a/src/static/historico.js
+++ b/src/static/historico.js
@@ -17,11 +17,13 @@ function loadHistory() {
             $('#historyTable').DataTable({
                 data: data,
                 columns: [
+                    { data: 'file' },
                     { data: 'timestamp' },
                     { data: 'total' },
                     { data: 'changes' },
                     { data: 'new' },
                     { data: 'removed' },
+                    { data: 'error_count' },
                     { data: 'status' }
                 ],
                 order: [[0, 'desc']],
@@ -46,7 +48,8 @@ function renderComparison(data) {
             new_price: c.new.price,
             variation: c.new.variation,
             type: 'cambio',
-            delta: c.new.price - c.old.price
+            delta: c.abs_diff,
+            pct: c.pct_diff
         });
     });
     (data.new || []).forEach(n => {
@@ -108,6 +111,8 @@ function renderComparison(data) {
             { data: 'old_price' },
             { data: 'new_price' },
             { data: 'variation' },
+            { data: 'delta' },
+            { data: 'pct' },
             { data: 'type' }
         ],
         dom: 'Bfrtip',


### PR DESCRIPTION
## Summary
- desactivar recarga automática de Flask y manejar `SIGINT` sin errores
- refrescar página existente con nuevo HAR en `bolsa_santiago_bot`
- guardar diffs de precios en `bolsa_service`
- usar base de datos como fuente principal en `history_view`
- mostrar todas las columnas en el histórico

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684799711b7c8330b981b1c48de424a2