### PR TITLE
Implement logs database and UI

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -10,3 +10,4 @@ from .credentials import Credential  # noqa: E402,F401
 from .column_preference import ColumnPreference  # noqa: E402,F401
 from .stock_filter import StockFilter  # noqa: E402,F401
 from .last_update import LastUpdate  # noqa: E402,F401
+from .log_entry import LogEntry  # noqa: E402,F401

--- a/src/models/log_entry.py
+++ b/src/models/log_entry.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from . import db
+
+class LogEntry(db.Model):
+    __tablename__ = 'log_entries'
+    id = db.Column(db.Integer, primary_key=True)
+    level = db.Column(db.String(20))
+    message = db.Column(db.Text, nullable=False)
+    action = db.Column(db.String(50))
+    stack = db.Column(db.Text)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow, index=True)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'level': self.level,
+            'message': self.message,
+            'action': self.action,
+            'stack': self.stack,
+            'timestamp': self.timestamp.strftime('%d/%m/%Y %H:%M:%S') if self.timestamp else None,
+        }

--- a/src/static/analisis.html
+++ b/src/static/analisis.html
@@ -21,6 +21,7 @@
                     <li class="nav-item"><a class="nav-link" href="/historico.html">Histórico</a></li>
                     <li class="nav-item"><a class="nav-link" href="/analisis.html">Análisis</a></li>
                     <li class="nav-item"><a class="nav-link" href="/arquitectura.html">Arquitectura</a></li>
+                <li class="nav-item"><a class="nav-link" href="/logs.html">Logs</a></li>
                 </ul>
                 <button id="themeToggle" class="btn btn-outline-light ms-lg-3" type="button" aria-label="Toggle theme"></button>
             </div>

--- a/src/static/arquitectura.html
+++ b/src/static/arquitectura.html
@@ -29,6 +29,7 @@
                     <li class="nav-item"><a class="nav-link" href="/historico.html">Histórico</a></li>
                     <li class="nav-item"><a class="nav-link" href="/analisis.html">Análisis</a></li>
                     <li class="nav-item"><a class="nav-link" href="/arquitectura.html">Arquitectura</a></li>
+                <li class="nav-item"><a class="nav-link" href="/logs.html">Logs</a></li>
                 </ul>
                 <button id="themeToggle" class="btn btn-outline-light ms-lg-3" type="button" aria-label="Toggle theme"></button>
             </div>

--- a/src/static/historico.html
+++ b/src/static/historico.html
@@ -23,6 +23,7 @@
                 <li class="nav-item"><a class="nav-link" href="/historico.html">Histórico</a></li>
                 <li class="nav-item"><a class="nav-link" href="/analisis.html">Análisis</a></li>
                 <li class="nav-item"><a class="nav-link" href="/arquitectura.html">Arquitectura</a></li>
+                <li class="nav-item"><a class="nav-link" href="/logs.html">Logs</a></li>
             </ul>
             <button id="themeToggle" class="btn btn-outline-light ms-lg-3" type="button" aria-label="Toggle theme"></button>
         </div>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -22,6 +22,7 @@
                     <li class="nav-item"><a class="nav-link" href="/historico.html">Histórico</a></li>
                     <li class="nav-item"><a class="nav-link" href="/analisis.html">Análisis</a></li>
                     <li class="nav-item"><a class="nav-link" href="/arquitectura.html">Arquitectura</a></li>
+                <li class="nav-item"><a class="nav-link" href="/logs.html">Logs</a></li>
                 </ul>
                 <button id="themeToggle" class="btn btn-outline-light ms-lg-3" type="button" aria-label="Toggle theme"></button>
             </div>

--- a/src/static/logs.html
+++ b/src/static/logs.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es" data-bs-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Logs</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/index.html">Bolsa App</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav me-auto">
+                <li class="nav-item"><a class="nav-link" href="/index.html">Inicio</a></li>
+                <li class="nav-item"><a class="nav-link" href="/historico.html">Histórico</a></li>
+                <li class="nav-item"><a class="nav-link" href="/analisis.html">Análisis</a></li>
+                <li class="nav-item"><a class="nav-link" href="/arquitectura.html">Arquitectura</a></li>
+                <li class="nav-item"><a class="nav-link active" aria-current="page" href="/logs.html">Logs</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<div class="container py-4">
+    <h1 class="mb-4">Logs</h1>
+    <div class="mb-3">
+        <input id="searchInput" class="form-control" placeholder="Buscar...">
+    </div>
+    <table id="logsTable" class="table table-striped">
+        <thead class="table-dark">
+            <tr>
+                <th>Id</th>
+                <th>Fecha</th>
+                <th>Acción</th>
+                <th>Mensaje</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/logs.js"></script>
+</body>
+</html>

--- a/src/static/logs.js
+++ b/src/static/logs.js
@@ -1,0 +1,46 @@
+async function loadLogs() {
+    const resp = await fetch('/api/logs');
+    const data = await resp.json();
+    const tbody = document.querySelector('#logsTable tbody');
+    tbody.innerHTML = '';
+    for (const log of data) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td>${log.id}</td>
+            <td>${log.timestamp}</td>
+            <td>${log.action}</td>
+            <td>${log.message}</td>
+            <td><button class="btn btn-sm btn-danger" data-id="${log.id}">Borrar</button></td>
+        `;
+        tbody.appendChild(tr);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    loadLogs();
+    document.querySelector('#searchInput').addEventListener('input', async (e) => {
+        const q = e.target.value;
+        const resp = await fetch('/api/logs?q=' + encodeURIComponent(q));
+        const data = await resp.json();
+        const tbody = document.querySelector('#logsTable tbody');
+        tbody.innerHTML = '';
+        for (const log of data) {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td>${log.id}</td>
+                <td>${log.timestamp}</td>
+                <td>${log.action}</td>
+                <td>${log.message}</td>
+                <td><button class="btn btn-sm btn-danger" data-id="${log.id}">Borrar</button></td>
+            `;
+            tbody.appendChild(tr);
+        }
+    });
+    document.querySelector('#logsTable').addEventListener('click', async (e) => {
+        if (e.target.matches('button[data-id]')) {
+            const id = e.target.getAttribute('data-id');
+            await fetch('/api/logs/' + id, {method: 'DELETE'});
+            loadLogs();
+        }
+    });
+});

--- a/tests/test_log_endpoint.py
+++ b/tests/test_log_endpoint.py
@@ -1,26 +1,18 @@
-import logging
 from src.routes import api as api_module
+from src.models.log_entry import LogEntry
 
 
-def test_log_endpoint_writes_message(app, tmp_path):
-    log_path = tmp_path / "frontend.log"
-    # replace logger handlers
-    for h in list(api_module.client_logger.handlers):
-        api_module.client_logger.removeHandler(h)
-    handler = logging.FileHandler(log_path, encoding="utf-8")
-    api_module.client_logger.addHandler(handler)
-    api_module.client_logger.setLevel(logging.INFO)
-
+def test_log_endpoint_writes_message(app):
     client = app.test_client()
     resp = client.post(
         "/api/logs",
         json={"message": "hello", "stack": "trace", "action": "test"},
     )
-    handler.flush()
     assert resp.status_code == 201
-    contents = log_path.read_text(encoding="utf-8")
-    assert "hello" in contents
-    assert "[test]" in contents
+    with app.app_context():
+        entry = LogEntry.query.first()
+        assert entry is not None
+        assert entry.message == "hello"
 
 
 def test_log_endpoint_requires_message(app):


### PR DESCRIPTION
## Summary
- add `LogEntry` model and database log storage
- expose REST endpoints to create/list/delete logs
- add logs page and JS to view and manage records
- link Logs page from site navigation
- ensure Playwright stubs work with tests
- update tests for new log behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ad5312f48330b8dc437cb7af8b1c