### PR TITLE
Switch Playwright logic to async API

### DIFF
--- a/src/automatizacion_bolsa/data_capture.py
+++ b/src/automatizacion_bolsa/data_capture.py
@@ -1,16 +1,16 @@
 from typing import Tuple, Any, Dict
-from playwright.sync_api import Page, BrowserContext
+from playwright.async_api import Page, BrowserContext
 
 from .config_loader import logger
 
 
-def capture_premium_data_via_network(page: Page) -> Tuple[bool, Dict[str, Any], str]:
+async def capture_premium_data_via_network(page: Page) -> Tuple[bool, Dict[str, Any], str]:
     """Placeholder para la captura de datos premium vía red."""
     logger.info("Capturando datos premium vía red")
     return False, {}, ""
 
 
-def fetch_premium_data(context: BrowserContext) -> Tuple[bool, Dict[str, Any], str]:
+async def fetch_premium_data(context: BrowserContext) -> Tuple[bool, Dict[str, Any], str]:
     """Placeholder para la obtención de datos premium por alternativas."""
     logger.info("Obteniendo datos premium por método alternativo")
     return False, {}, ""

--- a/src/automatizacion_bolsa/error_handling.py
+++ b/src/automatizacion_bolsa/error_handling.py
@@ -1,15 +1,15 @@
 from pathlib import Path
-from playwright.sync_api import Page
+from playwright.async_api import Page
 
 from .config_loader import logger, timestamp
 from .resources import HAR_FILENAME
 
 
-def capture_error_screenshot(page: Page) -> Path:
+async def capture_error_screenshot(page: Page) -> Path:
     """Guarda una captura de pantalla cuando ocurre una excepción."""
     screenshot = Path(f"error_{timestamp}.png")
     try:
-        page.screenshot(path=str(screenshot))
+        await page.screenshot(path=str(screenshot))
     except Exception as exc:
         logger.error(f"No se pudo guardar screenshot: {exc}")
     return screenshot

--- a/src/automatizacion_bolsa/login.py
+++ b/src/automatizacion_bolsa/login.py
@@ -1,4 +1,4 @@
-from playwright.sync_api import Page
+from playwright.async_api import Page
 
 from src.config import (
     USERNAME,
@@ -10,12 +10,12 @@ from src.config import (
 from .config_loader import logger
 
 
-def perform_login(page: Page) -> None:
+async def perform_login(page: Page) -> None:
     """Realiza el proceso de login estándar."""
     logger.info("Realizando login en Bolsa de Santiago")
-    page.fill(USERNAME_SELECTOR, USERNAME)
-    page.fill(PASSWORD_SELECTOR, PASSWORD)
-    page.click(LOGIN_BUTTON_SELECTOR)
+    await page.fill(USERNAME_SELECTOR, USERNAME)
+    await page.fill(PASSWORD_SELECTOR, PASSWORD)
+    await page.click(LOGIN_BUTTON_SELECTOR)
 
 
 __all__ = ["perform_login"]

--- a/src/automatizacion_bolsa/main.py
+++ b/src/automatizacion_bolsa/main.py
@@ -1,12 +1,17 @@
-from .config_loader import validate_credentials, configure_run_specific_logging, logger
+import asyncio
+from .config_loader import (
+    validate_credentials,
+    configure_run_specific_logging,
+    logger,
+)
 from .run_automation import run_automation
 
 
-def main():
+async def main():
     validate_credentials()
     configure_run_specific_logging(logger)
-    run_automation(logger)
+    await run_automation(logger)
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/src/automatizacion_bolsa/playwright_session.py
+++ b/src/automatizacion_bolsa/playwright_session.py
@@ -1,22 +1,24 @@
-from playwright.sync_api import sync_playwright
+from playwright.async_api import (
+    Playwright,
+    Browser,
+    BrowserContext,
+)
 
 from .config_loader import logger
 from src.config import INITIAL_PAGE_URL
 
-_p_instance = None
-_browser = None
-_context = None
+_browser: Browser | None = None
+_context: BrowserContext | None = None
 _page = None
 
 
-def create_page(sync_pw=sync_playwright):
+async def create_page(pw: Playwright) -> None:
     """Inicia Playwright y devuelve una nueva página."""
-    global _p_instance, _browser, _context, _page
-    _p_instance = sync_pw().start()
-    _browser = _p_instance.chromium.launch()
-    _context = _browser.new_context()
-    _page = _context.new_page()
-    _page.goto(INITIAL_PAGE_URL)
+    global _browser, _context, _page
+    _browser = await pw.chromium.launch()
+    _context = await _browser.new_context()
+    _page = await _context.new_page()
+    await _page.goto(INITIAL_PAGE_URL)
     return _page
 
 
@@ -24,15 +26,13 @@ def get_active_page():
     return _page
 
 
-def close_resources():
+async def close_resources() -> None:
     """Cierra de forma segura recursos de Playwright."""
     try:
         if _context:
-            _context.close()
+            await _context.close()
         if _browser:
-            _browser.close()
-        if _p_instance:
-            _p_instance.stop()
+            await _browser.close()
     except Exception as exc:
         logger.error(f"Error cerrando Playwright: {exc}")
 

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@ import os
 import sys
 import signal
 import atexit
+import asyncio
 
 # Add project root to Python path for absolute imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -45,7 +46,7 @@ def _cleanup_resources():
     try:
         from src.scripts.bolsa_santiago_bot import close_playwright_resources
 
-        close_playwright_resources()
+        asyncio.run(close_playwright_resources())
     except Exception as exc:
         print(f"Error al cerrar Playwright: {exc}")
 

--- a/src/scripts/bolsa_santiago_bot.py
+++ b/src/scripts/bolsa_santiago_bot.py
@@ -3,8 +3,8 @@
 import logging
 import os
 import random
-import time
-from playwright.sync_api import sync_playwright
+import asyncio
+from playwright.async_api import async_playwright
 
 from src.config import (
     INITIAL_PAGE_URL,
@@ -52,21 +52,21 @@ from src.automatizacion_bolsa.resources import (
 logger_instance_global = logger
 
 
-def run_automation(
+async def run_automation(
     log_instance: logging.Logger,
     max_attempts: int = 1,
     non_interactive: bool | None = None,
     keep_open: bool = True,
 ):
-    return _run_automation(
+    return await _run_automation(
         log_instance,
         max_attempts=max_attempts,
         non_interactive=non_interactive,
         keep_open=keep_open,
         capture_func=capture_premium_data_via_network,
         fetch_func=fetch_premium_data,
-        sync_pw=sync_playwright,
-        sleep_func=time.sleep,
+        async_pw=async_playwright,
+        sleep_func=asyncio.sleep,
         input_func=input,
     )
 

--- a/src/scripts/bolsa_service.py
+++ b/src/scripts/bolsa_service.py
@@ -3,6 +3,7 @@ import json
 import logging
 import time
 import subprocess
+import asyncio
 from datetime import datetime
 import threading
 import re
@@ -451,10 +452,12 @@ def run_bolsa_bot(
                 except Exception as cred_err:
                     logger.warning(f"Credenciales no configuradas: {cred_err}")
                 bot.configure_run_specific_logging(bot.logger_instance_global)
-                bot.run_automation(
-                    bot.logger_instance_global,
-                    non_interactive=os.getenv("BOLSA_NON_INTERACTIVE") == "1",
-                    keep_open=True,
+                asyncio.run(
+                    bot.run_automation(
+                        bot.logger_instance_global,
+                        non_interactive=os.getenv("BOLSA_NON_INTERACTIVE") == "1",
+                        keep_open=True,
+                    )
                 )
                 success, json_path = bot.refresh_active_page(bot.logger_instance_global)
 

--- a/tests/test_captcha_wait.py
+++ b/tests/test_captcha_wait.py
@@ -1,5 +1,6 @@
 import builtins
 from unittest import mock
+import asyncio
 
 import pytest
 
@@ -9,87 +10,106 @@ from src.scripts import bolsa_santiago_bot as bot
 class DummyLocator:
     def __init__(self, visible=False):
         self.visible = visible
-    def is_visible(self, timeout=0):
+
+    async def is_visible(self, timeout=0):
         return self.visible
-    def click(self):
+
+    async def click(self):
         pass
 
 class DummyPage:
     def __init__(self):
         self.url = bot.INITIAL_PAGE_URL
         self.wait_for_function_calls = []
-    def goto(self, url, timeout=None):
+    async def goto(self, url, timeout=None):
         self.url = url
-    def wait_for_url(self, *a, **k):
+
+    async def wait_for_url(self, *a, **k):
         pass
-    def wait_for_selector(self, *a, **k):
+
+    async def wait_for_selector(self, *a, **k):
         pass
-    def fill(self, selector, value):
+
+    async def fill(self, selector, value):
         pass
-    def click(self, selector):
+
+    async def click(self, selector):
         # Simulate redirection to captcha page after login
         self.url = "https://radware.example.com/captcha"
+
     def content(self):
         return "captcha page"
-    def wait_for_function(self, js, timeout=0):
+
+    async def wait_for_function(self, js, timeout=0):
         self.wait_for_function_calls.append((js, timeout))
+
     def locator(self, selector):
         return DummyLocator(False)
-    def wait_for_load_state(self, *a, **k):
+
+    async def wait_for_load_state(self, *a, **k):
         pass
+
     def on(self, *a, **k):
         pass
-    def reload(self, *a, **k):
+
+    async def reload(self, *a, **k):
         pass
-    def screenshot(self, *a, **k):
+
+    async def screenshot(self, *a, **k):
         pass
+
     def is_closed(self):
         return False
 
 class DummyContext:
     def __init__(self, page):
         self.page = page
-    def new_page(self):
+    async def new_page(self):
         return self.page
-    def close(self):
+
+    async def close(self):
         pass
 
 class DummyBrowser:
     def __init__(self, page):
         self.page = page
-    def new_context(self, **kwargs):
+    async def new_context(self, **kwargs):
         return DummyContext(self.page)
-    def close(self):
+
+    async def close(self):
         pass
 
 class DummyChromium:
     def __init__(self, page):
         self.page = page
-    def launch(self, **kwargs):
+    async def launch(self, **kwargs):
         return DummyBrowser(self.page)
 
 class DummyPlaywright:
     def __init__(self, page):
         self.chromium = DummyChromium(page)
-    def start(self):
+    async def __aenter__(self):
         return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
 
 
 def test_wait_on_captcha(monkeypatch):
     page = DummyPage()
     dummy_playwright = DummyPlaywright(page)
 
-    monkeypatch.setattr(bot, "sync_playwright", lambda: dummy_playwright)
+    monkeypatch.setattr(bot, "async_playwright", lambda: dummy_playwright)
     monkeypatch.setattr(bot, "analyze_har_and_extract_data", lambda *a, **k: None)
     monkeypatch.setattr(bot, "configure_run_specific_logging", lambda *a, **k: None)
     sleep_calls = []
-    def dummy_sleep(t):
+    async def dummy_sleep(t):
         sleep_calls.append(t)
-    monkeypatch.setattr(bot.time, "sleep", dummy_sleep)
+    monkeypatch.setattr(bot.asyncio, "sleep", lambda t: dummy_sleep(t))
     monkeypatch.setattr(bot.random, "uniform", lambda a, b: a)
     monkeypatch.setattr(builtins, "input", lambda *a, **k: "")
 
     logger = mock.Mock()
-    bot.run_automation(logger, max_attempts=1, non_interactive=False, keep_open=False)
+    asyncio.run(bot.run_automation(logger, max_attempts=1, non_interactive=False, keep_open=False))
 
     assert 10 in sleep_calls

--- a/tests/test_data_validation_restart.py
+++ b/tests/test_data_validation_restart.py
@@ -1,5 +1,6 @@
 import builtins
 from unittest import mock
+import asyncio
 
 import pytest
 
@@ -10,9 +11,10 @@ from src.config import MIS_CONEXIONES_TITLE_SELECTOR, CERRAR_TODAS_SESIONES_SELE
 class DummyLocator:
     def __init__(self, visible=True):
         self.visible = visible
-    def is_visible(self, timeout=0):
+    async def is_visible(self, timeout=0):
         return self.visible
-    def click(self):
+
+    async def click(self):
         pass
 
 
@@ -20,15 +22,19 @@ class DummyPage:
     def __init__(self, attempt_ref):
         self.attempt_ref = attempt_ref
         self.url = bot.INITIAL_PAGE_URL
-    def goto(self, url, timeout=None, wait_until=None):
+    async def goto(self, url, timeout=None, wait_until=None):
         self.url = url
-    def wait_for_url(self, *a, **k):
+
+    async def wait_for_url(self, *a, **k):
         pass
-    def wait_for_selector(self, *a, **k):
+
+    async def wait_for_selector(self, *a, **k):
         pass
-    def fill(self, *a, **k):
+
+    async def fill(self, *a, **k):
         pass
-    def click(self, *a, **k):
+
+    async def click(self, *a, **k):
         pass
     def content(self):
         return ""
@@ -38,13 +44,16 @@ class DummyPage:
         if selector == CERRAR_TODAS_SESIONES_SELECTOR:
             return DummyLocator(True)
         return DummyLocator(False)
-    def wait_for_load_state(self, *a, **k):
+    async def wait_for_load_state(self, *a, **k):
         pass
+
     def on(self, *a, **k):
         pass
-    def reload(self, *a, **k):
+
+    async def reload(self, *a, **k):
         pass
-    def screenshot(self, *a, **k):
+
+    async def screenshot(self, *a, **k):
         pass
     def is_closed(self):
         return False
@@ -53,59 +62,63 @@ class DummyPage:
 class DummyContext:
     def __init__(self, attempt_ref):
         self.attempt_ref = attempt_ref
-    def new_page(self):
+    async def new_page(self):
         self.attempt_ref[0] += 1
         return DummyPage(self.attempt_ref)
-    def close(self):
+
+    async def close(self):
         pass
-    def cookies(self):
+
+    async def cookies(self):
         return []
 
 
 class DummyBrowser:
     def __init__(self, attempt_ref):
         self.attempt_ref = attempt_ref
-    def new_context(self, **kwargs):
+    async def new_context(self, **kwargs):
         return DummyContext(self.attempt_ref)
-    def close(self):
+
+    async def close(self):
         pass
 
 
 class DummyChromium:
     def __init__(self, attempt_ref):
         self.attempt_ref = attempt_ref
-    def launch(self, **kwargs):
+    async def launch(self, **kwargs):
         return DummyBrowser(self.attempt_ref)
 
 
 class DummyPlaywright:
     def __init__(self, attempt_ref):
         self.chromium = DummyChromium(attempt_ref)
-    def start(self):
+    async def __aenter__(self):
         return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
 
 
 def test_restart_when_json_empty(monkeypatch):
     attempt_ref = [0]
     dummy_playwright = DummyPlaywright(attempt_ref)
-    monkeypatch.setattr(bot, "sync_playwright", lambda: dummy_playwright)
+    monkeypatch.setattr(bot, "async_playwright", lambda: dummy_playwright)
     monkeypatch.setattr(bot, "analyze_har_and_extract_data", lambda *a, **k: None)
     monkeypatch.setattr(bot, "configure_run_specific_logging", lambda *a, **k: None)
     monkeypatch.setenv("BOLSA_NON_INTERACTIVE", "1")
     monkeypatch.setattr(builtins, "input", lambda *a, **k: None)
 
-    monkeypatch.setattr(
-        bot,
-        "capture_premium_data_via_network",
-        lambda *a, **k: (True, {"listaResult": []}, "ts"),
-    )
-    monkeypatch.setattr(
-        bot,
-        "fetch_premium_data",
-        lambda *a, **k: (True, {"listaResult": []}, "ts"),
-    )
+    async def dummy_capture(*a, **k):
+        return True, {"listaResult": []}, "ts"
+
+    async def dummy_fetch(*a, **k):
+        return True, {"listaResult": []}, "ts"
+
+    monkeypatch.setattr(bot, "capture_premium_data_via_network", dummy_capture)
+    monkeypatch.setattr(bot, "fetch_premium_data", dummy_fetch)
 
     logger = mock.Mock()
-    bot.run_automation(logger, max_attempts=2, keep_open=False)
+    asyncio.run(bot.run_automation(logger, max_attempts=2, keep_open=False))
 
     assert attempt_ref[0] >= 2


### PR DESCRIPTION
## Summary
- migrate Playwright helpers to async API
- update automation entrypoints to async
- adjust flask cleanup to await async close
- adapt unit tests for async behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496d0ec38083308ea77f106b42c025