### PR TITLE
Add DB diagram and PowerShell how-to

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,3 +254,35 @@ el siguiente comando después de completar la instalación:
 pytest tests/test_database_connection.py
 ```
 
+## Consulta rápida con PowerShell
+
+Los siguientes pasos permiten conectarse a la base de datos de TimescaleDB y
+revisar el contenido de la tabla `stock_prices` desde PowerShell:
+
+1. Verifica que el contenedor de la base de datos esté en ejecución:
+
+   ```powershell
+   docker-compose up -d db
+   ```
+
+2. Conéctate utilizando `psql` (la contraseña por defecto es `postgres`):
+
+   ```powershell
+   psql -h localhost -U postgres -d bolsa
+   ```
+
+   Dentro de la consola de `psql` puedes consultar algunos registros:
+
+   ```sql
+   SELECT * FROM stock_prices LIMIT 5;
+   ```
+
+3. Para finalizar la sesión escribe `\q`.
+
+Si prefieres conectarte directamente al contenedor sin instalar `psql` en tu
+sistema, ejecuta:
+
+```powershell
+docker-compose exec db psql -U postgres -d bolsa
+```
+

--- a/diagrama_base_de_datos.md
+++ b/diagrama_base_de_datos.md
@@ -1,0 +1,42 @@
+# Diagrama de base de datos
+
+```mermaid
+erDiagram
+    STOCK_PRICES {
+        string symbol PK
+        datetime timestamp PK
+        float price
+        float variation
+    }
+    CREDENTIALS {
+        int id PK
+        string username
+        string password
+    }
+    USERS {
+        int id PK
+        string username
+        string email
+    }
+    COLUMN_PREFERENCES {
+        int id PK
+        text columns_json
+    }
+    STOCK_FILTERS {
+        int id PK
+        text codes_json
+        boolean all
+    }
+    LAST_UPDATE {
+        int id PK
+        datetime timestamp
+    }
+    LOG_ENTRIES {
+        int id PK
+        string level
+        text message
+        string action
+        text stack
+        datetime timestamp
+    }
+```


### PR DESCRIPTION
## Summary
- add mermaid ER diagram of the project's database schema
- document connecting to TimescaleDB via PowerShell

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68497747bcd08330b93d9e170b72e911