### PR TITLE
Add architecture view with schema diagram

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ flask-socketio==5.3.6
 psycopg2-binary==2.9.9
 pytest
 pyautogui
+
+sqlalchemy_schemadisplay
+pydot

--- a/src/main.py
+++ b/src/main.py
@@ -21,6 +21,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 from src.routes.api import api_bp
 from src.routes.user import user_bp
 from src.routes.errors import errors_bp
+from src.routes.architecture import architecture_bp
 
 # Crear la aplicación Flask
 app = Flask(__name__)
@@ -81,6 +82,7 @@ def load_saved_credentials():
 app.register_blueprint(api_bp, url_prefix="/api")
 app.register_blueprint(user_bp, url_prefix="/api")
 app.register_blueprint(errors_bp, url_prefix="/api")
+app.register_blueprint(architecture_bp)
 
 
 # Preguntar por la configuración de ejecución interactiva del bot

--- a/src/routes/architecture.py
+++ b/src/routes/architecture.py
@@ -1,0 +1,7 @@
+from flask import Blueprint, render_template
+
+architecture_bp = Blueprint("architecture", __name__)
+
+@architecture_bp.route("/architecture")
+def architecture_view():
+    return render_template("architecture.html")

--- a/src/templates/architecture.html
+++ b/src/templates/architecture.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block title %}Arquitectura de Base de Datos{% endblock %}
+{% block content %}
+  <h2>Arquitectura de Base de Datos</h2>
+  <p class="mb-3">A continuación se muestra el diagrama generado automáticamente a partir de los modelos actuales:</p>
+  <img src="{{ url_for('static', filename='schema_diagram.png') }}" alt="Diagrama de la base de datos" class="img-fluid border shadow">
+{% endblock %}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}Bolsa App{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/">Bolsa App</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav me-auto">
+                <li class="nav-item"><a class="nav-link" href="/">Inicio</a></li>
+                <li class="nav-item"><a class="nav-link" href="/history">Histórico</a></li>
+                <li class="nav-item"><a class="nav-link" href="/analysis">Análisis</a></li>
+                <li class="nav-item"><a class="nav-link" href="/architecture">Arquitectura</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<div class="container py-4">
+    {% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/utils/generate_schema_diagram.py
+++ b/src/utils/generate_schema_diagram.py
@@ -1,0 +1,21 @@
+from sqlalchemy_schemadisplay import create_schema_graph
+from src.models import db
+import os
+
+
+def generate_diagram():
+    graph = create_schema_graph(
+        metadata=db.metadata,
+        show_datatypes=True,
+        show_indexes=False,
+        rankdir="LR",
+        concentrate=False,
+    )
+    base_dir = os.path.dirname(os.path.dirname(__file__))
+    output_path = os.path.join(base_dir, "static", "schema_diagram.png")
+    graph.write_png(output_path)
+    print(f"Diagrama generado en: {output_path}")
+
+
+if __name__ == "__main__":
+    generate_diagram()


### PR DESCRIPTION
## Summary
- generate database diagram PNG from SQLAlchemy models
- create template base layout and architecture page
- add blueprint to serve the new view
- register blueprint in the Flask app
- document dependencies in requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68497b9d5dcc8330b0e68c555adbd217